### PR TITLE
Add countdown and fix resolving in timestamp

### DIFF
--- a/src/components/UI/molecules/reporting/CountdownTimer.jsx
+++ b/src/components/UI/molecules/reporting/CountdownTimer.jsx
@@ -1,8 +1,25 @@
-export const CountDownTimer = ({ title, startingTime }) => {
+import { useCountdown } from "@/lib/countdown/useCountdown";
+import dayjs from "dayjs";
+
+const getTime = () => {
+  return dayjs().unix().toString();
+};
+
+const formatCount = (n) => String(n).padStart(2, "0");
+
+export const CountDownTimer = ({ title, target }) => {
+  const { hours, minutes, seconds } = useCountdown({
+    target,
+    getTime,
+  });
+
+  const time = `${formatCount(hours)}:${formatCount(minutes)}:${formatCount(
+    seconds
+  )}`;
   return (
     <div className=" text-9B9B9B mt-4 mb-16 flex justify-center items-center flex-col">
-      <span className="text-xs font-semibold">{title}</span>
-      <span className="text-h3">{startingTime}</span>
+      <span className="text-xs font-semibold uppercase">{title}</span>
+      <span className="text-h3">{time}</span>
     </div>
   );
 };

--- a/src/components/UI/molecules/reporting/ResolveIncident.jsx
+++ b/src/components/UI/molecules/reporting/ResolveIncident.jsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { getCoverImgSrc } from "@/src/helpers/cover";
 import { CountDownTimer } from "@/components/UI/molecules/reporting/CountdownTimer";
 
-export const ResolveIncident = ({ incidentReport }) => {
+export const ResolveIncident = ({ incidentReport, resolvableTill }) => {
   const [isOpen, setIsOpen] = useState(false);
   const { resolve, emergencyResolve } = useResolveIncident({
     coverKey: incidentReport.key,
@@ -26,27 +26,25 @@ export const ResolveIncident = ({ incidentReport }) => {
   return (
     <div className="flex flex-col items-center">
       {incidentReport.resolved && (
-        <CountDownTimer title="Resolving in" startingTime=" 00:00:00" />
+        <CountDownTimer title="Resolving in" target={resolvableTill} />
       )}
 
       <div className="flex gap-10 mb-16">
         {!incidentReport.resolved && (
           <RegularButton
-            className="px-10 py-4 w-80  font-bold"
+            className="px-10 py-4 w-80  font-semibold"
             onClick={resolve}
           >
             RESOLVE
           </RegularButton>
         )}
 
-        {!incidentReport.emergencyResolved && (
-          <RegularButton
-            className="px-10 py-4 w-80 font-bold"
-            onClick={() => setIsOpen(true)}
-          >
-            EMERGENCY RESOLVE
-          </RegularButton>
-        )}
+        <RegularButton
+          className="px-10 py-4 w-80 font-semibold"
+          onClick={() => setIsOpen(true)}
+        >
+          EMERGENCY RESOLVE
+        </RegularButton>
 
         <EmergencyResolveModal
           isOpen={isOpen}
@@ -106,7 +104,7 @@ const EmergencyResolveModal = ({
         </div>
 
         <RegularButton
-          className="px-10 py-4 mt-12 w-full  font-semibold"
+          className="px-10 py-4 mt-12 w-full font-semibold"
           onClick={() => {
             emergencyResolve(decision === "true");
           }}

--- a/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
+++ b/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
@@ -37,13 +37,19 @@ export const UnstakeYourAmount = ({ incidentReport }) => {
   return (
     <div className="flex flex-col items-center pt-4">
       <span className={classNames("font-semibold", !isClaimableNow && "mb-4")}>
-        Result: Incident Occured
+        Result:{" "}
+        {incidentReport.decision ? "Incident Occured" : "False Reporting"}
       </span>
+
       {isClaimableNow && (
-        <CountDownTimer startingTime="00:00:00" title="CLAIM ENDS IN" />
+        <CountDownTimer
+          title="CLAIM ENDS IN"
+          target={incidentReport.claimExpiresAt}
+        />
       )}
+
       <RegularButton
-        className="px-10 py-4 mb-16 font-bold w-80"
+        className="px-10 py-4 mb-16 font-semibold w-80"
         onClick={() => setIsOpen(true)}
       >
         UNSTAKE

--- a/src/components/UI/organisms/reporting/ActiveReportSummary.jsx
+++ b/src/components/UI/organisms/reporting/ActiveReportSummary.jsx
@@ -14,7 +14,7 @@ import { formatWithAabbreviation } from "@/utils/formatter";
 import BigNumber from "bignumber.js";
 import dayjs from "dayjs";
 
-export const ActiveReportSummary = ({ incidentReport }) => {
+export const ActiveReportSummary = ({ incidentReport, resolvableTill }) => {
   const startDate = new Date(incidentReport.incidentDate * 1000);
   const endDate = new Date(incidentReport.resolutionTimestamp * 1000);
 
@@ -75,7 +75,10 @@ export const ActiveReportSummary = ({ incidentReport }) => {
           <Divider />
 
           {reportingEnded ? (
-            <ResolveIncident incidentReport={incidentReport} />
+            <ResolveIncident
+              incidentReport={incidentReport}
+              resolvableTill={resolvableTill}
+            />
           ) : (
             <CastYourVote incidentReport={incidentReport} />
           )}

--- a/src/components/UI/organisms/reporting/ResolvedReportSummary.jsx
+++ b/src/components/UI/organisms/reporting/ResolvedReportSummary.jsx
@@ -126,6 +126,7 @@ export const ResolvedReportSummary = ({ incidentReport }) => {
             {unixToDate(incidentReport.incidentDate, "D MMMM")} -{" "}
             {unixToDate(incidentReport.resolutionTimestamp, "D MMMM")}
           </p>
+
           <button className="text-4e7dd9 text-sm" onClick={finalize}>
             Finalize
           </button>

--- a/src/components/pages/reporting/details.jsx
+++ b/src/components/pages/reporting/details.jsx
@@ -5,14 +5,25 @@ import { ActiveReportSummary } from "@/components/UI/organisms/reporting/ActiveR
 import { Container } from "@/components/UI/atoms/container";
 import { ResolvedReportSummary } from "@/components/UI/organisms/reporting/ResolvedReportSummary";
 import dayjs from "dayjs";
-import { isGreater } from "@/utils/bn";
+import { isGreater, sumOf } from "@/utils/bn";
 
 export const ReportingDetailsPage = ({ incidentReport }) => {
   const { coverInfo } = useCoverInfo(incidentReport.key);
 
   const now = dayjs().unix();
+
+  let resolvableTill = incidentReport.claimBeginsFrom;
+
+  if (incidentReport.claimBeginsFrom === "0") {
+    const lastResolvedOn = incidentReport.emergencyResolved
+      ? incidentReport.emergencyResolveTransaction?.timestamp
+      : incidentReport.resolveTransaction?.timestamp;
+
+    resolvableTill = sumOf(lastResolvedOn, 24 * 60 * 60).toString();
+  }
+
   const showResolvedSummary =
-    incidentReport.resolved && isGreater(now, incidentReport.claimBeginsFrom);
+    incidentReport.resolved && isGreater(now, resolvableTill);
 
   return (
     <>
@@ -22,7 +33,10 @@ export const ReportingDetailsPage = ({ incidentReport }) => {
         {showResolvedSummary ? (
           <ResolvedReportSummary incidentReport={incidentReport} />
         ) : (
-          <ActiveReportSummary incidentReport={incidentReport} />
+          <ActiveReportSummary
+            incidentReport={incidentReport}
+            resolvableTill={resolvableTill}
+          />
         )}
 
         <RecentVotesTable


### PR DESCRIPTION
- Added countdown timer to "Resolving In" and "Claim Ends In" times
- Fix "Resolving In" timestamp based on last `resolve()` or `emergencyResolve()` transaction timestamps
- Shown "Emergency Resolve" button based on "Resolving In" timestamp instead of `claimBeginsAt` timestamp