### PR TITLE
Fix majority shown after reporting

### DIFF
--- a/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
+++ b/src/components/UI/molecules/reporting/UnstakeYourAmount.jsx
@@ -7,7 +7,7 @@ import { classNames } from "@/lib/toast/utils";
 import { getCoverImgSrc } from "@/src/helpers/cover";
 import { useCoverInfo } from "@/src/hooks/useCoverInfo";
 import { useUnstakeReportingStake } from "@/src/hooks/useUnstakeReportingStake";
-import { isGreater } from "@/utils/bn";
+import { convertFromUnits, isGreater, sumOf } from "@/utils/bn";
 import { Dialog } from "@headlessui/react";
 import dayjs from "dayjs";
 import { useState } from "react";
@@ -38,7 +38,8 @@ export const UnstakeYourAmount = ({ incidentReport }) => {
     <div className="flex flex-col items-center pt-4">
       <span className={classNames("font-semibold", !isClaimableNow && "mb-4")}>
         Result:{" "}
-        {incidentReport.decision ? "Incident Occured" : "False Reporting"}
+        {incidentReport.decision ? "Incident Occured" : "False Reporting"}{" "}
+        {incidentReport.emergencyResolved && "(Emergency Resolved)"}
       </span>
 
       {isClaimableNow && (
@@ -59,7 +60,11 @@ export const UnstakeYourAmount = ({ incidentReport }) => {
         isOpen={isOpen}
         onClose={onClose}
         unstake={handleUnstake}
-        reward={+info.myStakeInWinningCamp + +info.myReward}
+        reward={convertFromUnits(
+          sumOf(info.myStakeInWinningCamp, info.myReward).toString()
+        )
+          .decimalPlaces(2)
+          .toString()}
         logoSrc={logoSrc}
         altName={coverInfo?.coverName}
       />

--- a/src/components/UI/organisms/reporting/ActiveReportSummary.jsx
+++ b/src/components/UI/organisms/reporting/ActiveReportSummary.jsx
@@ -34,8 +34,15 @@ export const ActiveReportSummary = ({ incidentReport, resolvableTill }) => {
     .decimalPlaces(2)
     .toNumber();
 
-  const isAttestedWon =
-    incidentReport.totalAttestedCount > incidentReport.totalRefutedCount;
+  let isAttestedWon = incidentReport.decision;
+
+  if (incidentReport.decision === null) {
+    isAttestedWon = isGreater(
+      incidentReport.totalAttestedStake,
+      incidentReport.totalRefutedStake
+    );
+  }
+
   const majority = {
     voteCount: isAttestedWon
       ? incidentReport.totalAttestedCount

--- a/src/components/UI/organisms/reporting/ResolvedReportSummary.jsx
+++ b/src/components/UI/organisms/reporting/ResolvedReportSummary.jsx
@@ -4,7 +4,7 @@ import { InsightsTable } from "@/components/UI/molecules/reporting/InsightsTable
 import { UnstakeYourAmount } from "@/components/UI/molecules/reporting/UnstakeYourAmount";
 import { VotesSummaryHorizantalChart } from "@/components/UI/organisms/reporting/VotesSummaryHorizantalChart";
 import { Divider } from "@/components/UI/atoms/divider";
-import { convertFromUnits } from "@/utils/bn";
+import { convertFromUnits, isGreater } from "@/utils/bn";
 import BigNumber from "bignumber.js";
 import { formatWithAabbreviation } from "@/utils/formatter";
 import { truncateAddress } from "@/utils/address";
@@ -33,8 +33,15 @@ export const ResolvedReportSummary = ({ incidentReport }) => {
     .decimalPlaces(2)
     .toNumber();
 
-  const isAttestedWon =
-    incidentReport.totalAttestedCount > incidentReport.totalRefutedCount;
+  let isAttestedWon = incidentReport.decision;
+
+  if (incidentReport.decision === null) {
+    isAttestedWon = isGreater(
+      incidentReport.totalAttestedStake,
+      incidentReport.totalRefutedStake
+    );
+  }
+
   const majority = {
     voteCount: isAttestedWon
       ? incidentReport.totalAttestedCount


### PR DESCRIPTION
- If `resolved` show the winning camp based on `decision`.
- If not resolved, show the majority based on total NPM staked.
- Handle errors for `unstake` and `unstakeWithClaim` 

<img width="1249" alt="image" src="https://user-images.githubusercontent.com/82953782/154472286-5c2a8692-3035-4a75-b617-11833193422b.png">
