### PR TITLE
Firefox CSP

### DIFF
--- a/http/headers.production.js
+++ b/http/headers.production.js
@@ -7,7 +7,7 @@ module.exports = [
       "style-src 'self' 'unsafe-inline'",
       "upgrade-insecure-requests",
       "frame-ancestors 'none'",
-      "default-src 'none'",
+      "default-src 'self'",
       "prefetch-src 'self'",
       "manifest-src 'self'",
       "base-uri 'none'",


### PR DESCRIPTION
Changed default-src to 'self' to fix Firefox console errors