### PR TITLE
Add feature to control unlimited approvals

### DIFF
--- a/src/components/UI/organisms/cover-form/ProvideLiquidityForm.jsx
+++ b/src/components/UI/organisms/cover-form/ProvideLiquidityForm.jsx
@@ -1,7 +1,7 @@
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 
-import { convertFromUnits, sumOf } from "@/utils/bn";
+import { convertFromUnits, sumOf, isGreater, convertToUnits } from "@/utils/bn";
 import { OutlinedButton } from "@/components/UI/atoms/button/outlined";
 import { TokenAmountInput } from "@/components/UI/organisms/token-amount-input";
 import { RegularButton } from "@/components/UI/atoms/button/regular";
@@ -72,7 +72,7 @@ export const ProvideLiquidityForm = ({ coverKey, info }) => {
   const unlockTimestamp = sumOf(DateLib.unix(), info?.lockup || "0");
 
   useEffect(() => {
-    if (npmBalance && npmValue < 250) {
+    if (isGreater(minNpmStake, convertToUnits(npmValue || "0"))) {
       setNpmErrorMsg("Insufficient Stake");
     } else if (
       npmBalance &&
@@ -107,8 +107,12 @@ export const ProvideLiquidityForm = ({ coverKey, info }) => {
           inputValue={npmValue}
           disabled={lqApproving || providing}
         >
-          Minimum Stake: {convertFromUnits(minNpmStake).toString()}{" "}
-          {npmTokenSymbol}
+          {isGreater(minNpmStake, "0") && (
+            <>
+              Minimum Stake: {convertFromUnits(minNpmStake).toString()}{" "}
+              {npmTokenSymbol}
+            </>
+          )}
           {npmErrorMsg && (
             <p className="flex items-center text-FA5C2F">{npmErrorMsg}</p>
           )}

--- a/src/components/UI/organisms/header/AccountDetailsModal.jsx
+++ b/src/components/UI/organisms/header/AccountDetailsModal.jsx
@@ -2,13 +2,14 @@ import { Dialog } from "@headlessui/react";
 import CloseIcon from "@/icons/CloseIcon";
 import CopyIcon from "@/icons/CopyIcon";
 import OpenInNewIcon from "@/icons/OpenInNewIcon";
-import DisconnectIcon from "@/icons/disconnect-icon";
 import { wallets } from "@/lib/connect-wallet/config/wallets";
 import { getAddressLink } from "@/lib/connect-wallet/utils/explorer";
 import Identicon from "@/components/UI/organisms/header/Identicon";
 import { useEffect, useState } from "react";
 import CheckCircleIcon from "@/icons/CheckCircleIcon";
 import { Modal } from "@/components/UI/molecules/modal/regular";
+import { Toggle } from "@/components/common/Toggle";
+import { useUnlimitedApproval } from "@/src/context/UnlimitedApproval";
 
 const CopyAddressComponent = ({ account }) => {
   const [copyAddress, setCopyAddress] = useState(false);
@@ -59,6 +60,7 @@ export const AccountDetailsModal = ({
   account,
 }) => {
   const network = wallets.find((x) => x.id == "1");
+  const { unlimitedApproval, setUnlimitedApproval } = useUnlimitedApproval();
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
@@ -79,15 +81,18 @@ export const AccountDetailsModal = ({
         </button>
 
         <div className="mt-7 border border-B0C4DB bg-white rounded-big p-4">
-          <div className="flex items-center">
+          <div className="flex items-center justify-between">
             <span className="text-364253 text-xs tracking-normal whitespace-nowrap flex items-center">
               <span>Connected With {network.name}</span>
               <span className="ml-2">
                 {<network.Icon width={12} height={12} />}
               </span>
             </span>
-            <button className="border border-4e7dd9 ml-28 rounded-lg py-1 px-2 text-xxs text-4e7dd9">
-              Change
+            <button
+              onClick={handleDisconnect}
+              className="border border-4e7dd9 ml-28 rounded-lg py-1 px-2 text-xxs text-4e7dd9"
+            >
+              Disconnect
             </button>
           </div>
 
@@ -114,13 +119,19 @@ export const AccountDetailsModal = ({
           </div>
         </div>
 
-        <button
-          onClick={handleDisconnect}
-          className="w-full mt-8 border bg-white border-B0C4DB rounded-big p-4 flex items-center"
-        >
-          <DisconnectIcon className="fill-364253" />
-          <span className="text-364253 ml-4">Disconnect</span>
-        </button>
+        <div className="w-full mt-8 border border-B0C4DB rounded-big p-5 flex flex-col">
+          <div className="flex w-full justify-between items-center">
+            <p className="text-h5 text-364253">Unlimited Approvals</p>
+            <Toggle
+              enabled={unlimitedApproval}
+              setEnabled={setUnlimitedApproval}
+            />
+          </div>
+          <p className="text-999BAB mt-3 text-xs tracking-normal leading-4.5">
+            If you do not want to keep approving for each transaction, enable
+            this box.
+          </p>
+        </div>
       </div>
     </Modal>
   );

--- a/src/components/common/Toggle.jsx
+++ b/src/components/common/Toggle.jsx
@@ -1,0 +1,21 @@
+import { Switch } from "@headlessui/react";
+
+export function Toggle({ enabled, setEnabled }) {
+  return (
+    <div className="">
+      <Switch
+        checked={enabled}
+        onChange={setEnabled}
+        className={`${enabled ? "bg-4e7dd9" : "bg-B0C4DB"}
+          relative inline-flex flex-shrink-0 h-4 w-8 border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus-visible:ring-2  focus-visible:ring-white focus-visible:ring-opacity-75`}
+      >
+        <span className="sr-only">Use setting</span>
+        <span
+          aria-hidden="true"
+          className={`${enabled ? "translate-x-4" : "translate-x-0"}
+            pointer-events-none inline-block h-3 w-3 rounded-full bg-white shadow-lg transform ring-0 transition ease-in-out duration-200`}
+        />
+      </Switch>
+    </div>
+  );
+}

--- a/src/context/UnlimitedApproval.jsx
+++ b/src/context/UnlimitedApproval.jsx
@@ -1,0 +1,33 @@
+import { useLocalStorage } from "@/src/hooks/useLocalStorage";
+import React from "react";
+
+const UnlimitedApprovalContext = React.createContext({
+  unlimitedApproval: false,
+  setUnlimitedApproval: () => {},
+});
+
+export function useUnlimitedApproval() {
+  const context = React.useContext(UnlimitedApprovalContext);
+
+  if (context === undefined) {
+    throw new Error(
+      "useUnlimitedApproval must be used within a UnlimitedApprovalProvider"
+    );
+  }
+  return context;
+}
+
+export const UnlimitedApprovalProvider = ({ children }) => {
+  const [unlimitedApproval, setUnlimitedApproval] = useLocalStorage(
+    "unlimitedApproval",
+    false
+  );
+
+  return (
+    <UnlimitedApprovalContext.Provider
+      value={{ unlimitedApproval, setUnlimitedApproval }}
+    >
+      {children}
+    </UnlimitedApprovalContext.Provider>
+  );
+};

--- a/src/helpers/store/getRemainingMinStakeToAddLiquidity.js
+++ b/src/helpers/store/getRemainingMinStakeToAddLiquidity.js
@@ -1,0 +1,46 @@
+import { utils } from "@neptunemutual/sdk";
+import { getStoredData } from "@/src/helpers/store";
+import { convertToUnits } from "@/utils/bn";
+import BigNumber from "bignumber.js";
+
+export const getRemainingMinStakeToAddLiquidity = async (
+  networkId,
+  coverKey,
+  account,
+  provider
+) => {
+  const candidates = [
+    {
+      key: [utils.keyUtil.PROTOCOL.NS.COVER_LIQUIDITY_MIN_STAKE],
+      returns: "uint256",
+      property: "minStakeToAddLiquidity",
+      compute: async ({ value }) => {
+        if (value.toString() === "0") {
+          return convertToUnits(250).toString();
+        }
+
+        return value.toString();
+      },
+    },
+    {
+      key: [utils.keyUtil.PROTOCOL.NS.COVER_LIQUIDITY_STAKE, coverKey, account],
+      signature: ["bytes32", "bytes32", "address"],
+      returns: "uint256",
+      property: "myStake",
+      compute: async ({ value }) => {
+        return value.toString();
+      },
+    },
+    {
+      returns: "uint256",
+      property: "remaining",
+      compute: async ({ result }) => {
+        const { minStakeToAddLiquidity, myStake } = result;
+        return BigNumber(minStakeToAddLiquidity).minus(myStake).toString();
+      },
+    },
+  ];
+
+  const result = await getStoredData(candidates, networkId, provider);
+  return result.remaining;
+};

--- a/src/hooks/provide-liquidity/useProvideLiquidity.jsx
+++ b/src/hooks/provide-liquidity/useProvideLiquidity.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import { liquidity, registry } from "@neptunemutual/sdk";
 import { useWeb3React } from "@web3-react/core";
-import { AddressZero } from "@ethersproject/constants";
 
 import {
   convertToUnits,
@@ -16,8 +15,8 @@ import { useTokenSymbol } from "@/src/hooks/useTokenSymbol";
 import { useNPMBalance } from "@/src/hooks/useNPMBalance";
 import { useErrorNotifier } from "@/src/hooks/useErrorNotifier";
 import { useAppContext } from "@/src/context/AppWrapper";
-import { getMinStakeToAddLiquidity } from "@/src/helpers/store/getMinStakeToAddLiquidity";
 import { useApprovalAmount } from "@/src/hooks/useApprovalAmount";
+import { getRemainingMinStakeToAddLiquidity } from "@/src/helpers/store/getRemainingMinStakeToAddLiquidity";
 
 export const useProvideLiquidity = ({ coverKey, lqValue, npmValue }) => {
   const [lqTokenAllowance, setLqTokenAllowance] = useState();
@@ -40,22 +39,19 @@ export const useProvideLiquidity = ({ coverKey, lqValue, npmValue }) => {
 
   useEffect(() => {
     let ignore = false;
-    if (!networkId) return;
+    if (!networkId || !account || !coverKey) return;
 
     async function fetchMinStake() {
-      const signerOrProvider = getProviderOrSigner(
-        library,
-        AddressZero,
-        networkId
-      );
+      const signerOrProvider = getProviderOrSigner(library, account, networkId);
 
-      const _minNpmStake = await getMinStakeToAddLiquidity(
+      const _minNpmStake = await getRemainingMinStakeToAddLiquidity(
         networkId,
+        coverKey,
+        account,
         signerOrProvider.provider
       );
 
       if (ignore) return;
-      console.log(_minNpmStake);
       setMinNpmStake(_minNpmStake);
     }
 
@@ -64,7 +60,7 @@ export const useProvideLiquidity = ({ coverKey, lqValue, npmValue }) => {
     return () => {
       ignore = true;
     };
-  }, [library, networkId]);
+  }, [account, coverKey, library, networkId]);
 
   useEffect(() => {
     let ignore = false;

--- a/src/hooks/useApprovalAmount.jsx
+++ b/src/hooks/useApprovalAmount.jsx
@@ -1,7 +1,8 @@
+import { useUnlimitedApproval } from "@/src/context/UnlimitedApproval";
 import { MaxUint256 } from "@ethersproject/constants";
 
 export const useApprovalAmount = () => {
-  const unlimitedApproval = true;
+  const { unlimitedApproval } = useUnlimitedApproval();
 
   /**
    * @param {string} amount

--- a/src/hooks/useLocalStorage.jsx
+++ b/src/hooks/useLocalStorage.jsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+// Hook
+export function useLocalStorage(key, initialValue) {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState(() => {
+    if (!process.browser) return;
+
+    try {
+      // Get from local storage by key
+      const item = window.localStorage.getItem(key);
+      // Parse stored json or if none return initialValue
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      // If error also return initialValue
+      console.log(error);
+      return initialValue;
+    }
+  });
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value) => {
+    if (!process.browser) return;
+
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore =
+        value instanceof Function ? value(storedValue) : value;
+      // Save state
+      setStoredValue(valueToStore);
+      // Save to local storage
+      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error);
+    }
+  };
+  return [storedValue, setValue];
+}

--- a/src/pages/_app.jsx
+++ b/src/pages/_app.jsx
@@ -10,6 +10,7 @@ import { AppWrapper } from "@/src/context/AppWrapper";
 import { ToastProvider } from "@/lib/toast/provider";
 import { AppConstantsProvider } from "@/src/context/AppConstants";
 import { CoversProvider } from "@/src/context/Covers";
+import { UnlimitedApprovalProvider } from "@/src/context/UnlimitedApproval";
 
 const position = {
   variant: "top_right",
@@ -25,10 +26,12 @@ function MyApp({ Component, pageProps }) {
       <AppWrapper>
         <AppConstantsProvider>
           <CoversProvider>
-            <ToastProvider variant={position.variant}>
-              <Header></Header>
-              <Component {...pageProps} />
-            </ToastProvider>
+            <UnlimitedApprovalProvider>
+              <ToastProvider variant={position.variant}>
+                <Header></Header>
+                <Component {...pageProps} />
+              </ToastProvider>
+            </UnlimitedApprovalProvider>
           </CoversProvider>
         </AppConstantsProvider>
       </AppWrapper>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,6 +62,9 @@ module.exports = {
         /* 72px */
         18: "4.5rem",
       },
+      lineHeight: {
+        4.5: "18px",
+      },
       maxWidth: {
         180: "180px",
       },


### PR DESCRIPTION
- Allow user to enable/disable unlimited approvals
- Store user preference in local storage
- Disabled the unlimited approvals by default.
- Update minimum NPM stake to add liquidity required depending on previously staked