### PR TITLE
Refresh state when the timer ends

### DIFF
--- a/src/components/UI/molecules/reporting/ResolveIncident.jsx
+++ b/src/components/UI/molecules/reporting/ResolveIncident.jsx
@@ -9,7 +9,11 @@ import { useState } from "react";
 import { getCoverImgSrc } from "@/src/helpers/cover";
 import { CountDownTimer } from "@/components/UI/molecules/reporting/CountdownTimer";
 
-export const ResolveIncident = ({ incidentReport, resolvableTill }) => {
+export const ResolveIncident = ({
+  refetchReport,
+  incidentReport,
+  resolvableTill,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const { resolve, emergencyResolve } = useResolveIncident({
     coverKey: incidentReport.key,
@@ -33,7 +37,10 @@ export const ResolveIncident = ({ incidentReport, resolvableTill }) => {
         {!incidentReport.resolved && (
           <RegularButton
             className="px-10 py-4 w-full md:w-80  font-semibold uppercase"
-            onClick={resolve}
+            onClick={async () => {
+              await resolve();
+              setTimeout(refetchReport, 15000);
+            }}
           >
             Resolve
           </RegularButton>
@@ -49,6 +56,7 @@ export const ResolveIncident = ({ incidentReport, resolvableTill }) => {
         <EmergencyResolveModal
           isOpen={isOpen}
           onClose={onClose}
+          refetchReport={refetchReport}
           emergencyResolve={emergencyResolve}
           logoSource={logoSource}
           logoAlt={coverInfo?.coverName}
@@ -61,6 +69,7 @@ export const ResolveIncident = ({ incidentReport, resolvableTill }) => {
 const EmergencyResolveModal = ({
   isOpen,
   onClose,
+  refetchReport,
   emergencyResolve,
   logoSource,
   logoAlt,
@@ -81,7 +90,9 @@ const EmergencyResolveModal = ({
             alt={logoAlt}
             src={logoSource}
           />
-          <h3 className="font-sora font-bold text-h2">Emergency Resolution</h3>
+          <div className="font-sora font-bold text-h2">
+            Emergency Resolution
+          </div>
         </Dialog.Title>
         <div className="mt-8 mb-6 font-semibold uppercase">
           Select Your Decision
@@ -105,8 +116,9 @@ const EmergencyResolveModal = ({
 
         <RegularButton
           className="px-10 py-4 mt-12 w-full font-semibold"
-          onClick={() => {
-            emergencyResolve(decision === "true");
+          onClick={async () => {
+            await emergencyResolve(decision === "true");
+            setTimeout(refetchReport, 15000);
           }}
         >
           EMERGENCY RESOLVE

--- a/src/components/UI/organisms/policy/PolicyCard/index.jsx
+++ b/src/components/UI/organisms/policy/PolicyCard/index.jsx
@@ -36,8 +36,8 @@ export const PolicyCard = ({ policyInfo }) => {
   return (
     <div className="rounded-3xl focus:outline-none focus-visible:ring-2 focus-visible:ring-4e7dd9">
       <OutlinedCard className="bg-white p-6" type="normal">
-        <div className="flex justify-between">
-          <div>
+        <div>
+          <div className="flex justify-between">
             <div className="w-18 h-18 bg-DEEAF6 p-3 rounded-full">
               <img
                 src={imgSrc}
@@ -45,21 +45,22 @@ export const PolicyCard = ({ policyInfo }) => {
                 className="inline-block max-w-full"
               />
             </div>
-            <h4 className="text-h4 font-sora font-semibold uppercase mt-4">
-              {coverInfo.projectName}
-            </h4>
+
+            <div>
+              {status && (
+                <Badge
+                  className={classNames(
+                    statusType == "failure" ? " text-FA5C2F" : "text-21AD8C"
+                  )}
+                >
+                  <IncidentReportStatus status={status} />
+                </Badge>
+              )}
+            </div>
           </div>
-          <div>
-            {status && (
-              <Badge
-                className={classNames(
-                  statusType == "failure" ? " text-FA5C2F" : "text-21AD8C"
-                )}
-              >
-                <IncidentReportStatus status={status} />
-              </Badge>
-            )}
-          </div>
+          <h4 className="text-h4 font-sora font-semibold uppercase mt-4">
+            {coverInfo.projectName}
+          </h4>
         </div>
 
         {/* Divider */}

--- a/src/components/UI/organisms/pools/pod-staking/PodStakingCard.jsx
+++ b/src/components/UI/organisms/pools/pod-staking/PodStakingCard.jsx
@@ -174,7 +174,9 @@ export const PodStakingCard = ({ data }) => {
         lockupPeriod={lockupPeriod}
         poolKey={poolKey}
         info={info}
-        modalTitle={<ModalTitle imgSrc={imgSrc}>{poolName}</ModalTitle>}
+        modalTitle={
+          <ModalTitle imgSrc={imgSrc}>Stake {stakingTokenSymbol}</ModalTitle>
+        }
         onClose={onStakeModalClose}
         isOpen={isStakeModalOpen}
         unitName={stakingTokenSymbol}
@@ -190,7 +192,7 @@ export const PodStakingCard = ({ data }) => {
         isCollectModalOpen={isCollectModalOpen}
         onCollectModalClose={onCollectModalClose}
         modalTitle={
-          <ModalTitle imgSrc={imgSrc}>Collect {stakingTokenSymbol}</ModalTitle>
+          <ModalTitle imgSrc={imgSrc}>Earn {rewardTokenSymbol}</ModalTitle>
         }
         unitName={stakingTokenSymbol}
       />

--- a/src/components/UI/organisms/pools/staking/StakingCard.jsx
+++ b/src/components/UI/organisms/pools/staking/StakingCard.jsx
@@ -5,7 +5,6 @@ import { DoubleImage } from "@/components/common/DoubleImage";
 import { StakingCardTitle } from "@/components/UI/molecules/pools/staking/StakingCardTitle";
 import { StakingCardSubTitle } from "@/components/UI/molecules/pools/staking/StakingCardSubTitle";
 import { StakingCardCTA } from "@/components/UI/molecules/pools/staking/StakingCardCTA";
-import { ModalTitle } from "@/components/UI/molecules/modal/ModalTitle";
 import { StakeModal } from "@/components/UI/organisms/pools/staking/StakeModal";
 import { OutlinedCard } from "@/components/UI/molecules/outlined-card";
 import BigNumber from "bignumber.js";
@@ -119,7 +118,18 @@ export const StakingCard = ({ data }) => {
   );
 
   const collectModalTitle = (
-    <ModalTitle imgSrc={npmImgSrc}>Collect {stakingTokenSymbol}</ModalTitle>
+    <div className="flex items-center">
+      <div className="mr-8">
+        <DoubleImage
+          images={[
+            { src: npmImgSrc, alt: "NPM" },
+            { src: imgSrc, alt: rewardTokenSymbol },
+          ]}
+        />
+      </div>
+
+      <h3>Earn {rewardTokenSymbol}</h3>
+    </div>
   );
 
   return (

--- a/src/components/UI/organisms/reporting/ActiveReportSummary.jsx
+++ b/src/components/UI/organisms/reporting/ActiveReportSummary.jsx
@@ -13,10 +13,15 @@ import DateLib from "@/lib/date/DateLib";
 import { formatCurrency } from "@/utils/formatter/currency";
 import { formatPercent } from "@/utils/formatter/percent";
 import { VotesSummaryHorizontalChart } from "@/components/UI/organisms/reporting/VotesSummaryHorizontalChart";
+import { useRetryUntilPassed } from "@/src/hooks/useRetryUntilPassed";
 
-export const ActiveReportSummary = ({ incidentReport, resolvableTill }) => {
-  const startDate = new Date(incidentReport.incidentDate * 1000);
-  const endDate = new Date(incidentReport.resolutionTimestamp * 1000);
+export const ActiveReportSummary = ({
+  refetchReport,
+  incidentReport,
+  resolvableTill,
+}) => {
+  const startDate = DateLib.fromUnix(incidentReport.incidentDate);
+  const endDate = DateLib.fromUnix(incidentReport.resolutionTimestamp);
 
   const votes = {
     yes: convertFromUnits(incidentReport.totalAttestedStake)
@@ -55,6 +60,12 @@ export const ActiveReportSummary = ({ incidentReport, resolvableTill }) => {
   const now = DateLib.unix();
   const reportingEnded = isGreater(now, incidentReport.resolutionTimestamp);
 
+  // Refreshes when reporting period ends
+  useRetryUntilPassed(() => {
+    const _now = DateLib.unix();
+    return isGreater(_now, incidentReport.resolutionTimestamp);
+  }, true);
+
   return (
     <>
       <OutlinedCard className="md:flex bg-white">
@@ -86,6 +97,7 @@ export const ActiveReportSummary = ({ incidentReport, resolvableTill }) => {
               <ResolveIncident
                 incidentReport={incidentReport}
                 resolvableTill={resolvableTill}
+                refetchReport={refetchReport}
               />
             ) : (
               <CastYourVote incidentReport={incidentReport} />

--- a/src/components/UI/organisms/reporting/ResolvedReportSummary.jsx
+++ b/src/components/UI/organisms/reporting/ResolvedReportSummary.jsx
@@ -11,7 +11,7 @@ import { formatCurrency } from "@/utils/formatter/currency";
 import DateLib from "@/lib/date/DateLib";
 import { VotesSummaryHorizontalChart } from "@/components/UI/organisms/reporting/VotesSummaryHorizontalChart";
 
-export const ResolvedReportSummary = ({ incidentReport }) => {
+export const ResolvedReportSummary = ({ incidentReport, refetchReport }) => {
   const { finalize } = useFinalizeIncident({
     coverKey: incidentReport.key,
     incidentDate: incidentReport.incidentDate,
@@ -156,7 +156,13 @@ export const ResolvedReportSummary = ({ incidentReport }) => {
           </p>
 
           {!incidentReport.finalized && (
-            <button className="text-4e7dd9 text-sm" onClick={finalize}>
+            <button
+              className="text-4e7dd9 text-sm"
+              onClick={async () => {
+                await finalize();
+                setTimeout(refetchReport, 15000);
+              }}
+            >
               Finalize
             </button>
           )}

--- a/src/components/pages/reporting/details.jsx
+++ b/src/components/pages/reporting/details.jsx
@@ -6,11 +6,18 @@ import { ResolvedReportSummary } from "@/components/UI/organisms/reporting/Resol
 import DateLib from "@/lib/date/DateLib";
 import { isGreater } from "@/utils/bn";
 import { ActiveReportSummary } from "@/components/UI/organisms/reporting/ActiveReportSummary";
+import { useRetryUntilPassed } from "@/src/hooks/useRetryUntilPassed";
 
-export const ReportingDetailsPage = ({ incidentReport }) => {
+export const ReportingDetailsPage = ({ incidentReport, refetchReport }) => {
   const { coverInfo } = useCoverInfo(incidentReport.key);
 
   const now = DateLib.unix();
+
+  // Refreshes when resolution deadline passed (when reporting becomes unresolvable)
+  useRetryUntilPassed(() => {
+    const _now = DateLib.unix();
+    return isGreater(_now, incidentReport.resolutionDeadline);
+  }, true);
 
   const showResolvedSummary =
     incidentReport.resolved &&
@@ -25,9 +32,13 @@ export const ReportingDetailsPage = ({ incidentReport }) => {
       <hr className="border-b border-B0C4DB" />
       <Container className="py-16">
         {showResolvedSummary ? (
-          <ResolvedReportSummary incidentReport={incidentReport} />
+          <ResolvedReportSummary
+            refetchReport={refetchReport}
+            incidentReport={incidentReport}
+          />
         ) : (
           <ActiveReportSummary
+            refetchReport={refetchReport}
             incidentReport={incidentReport}
             resolvableTill={incidentReport.resolutionDeadline}
           />

--- a/src/hooks/useFetchReport.jsx
+++ b/src/hooks/useFetchReport.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { getGraphURL } from "@/src/config/environment";
 import { useAppContext } from "@/src/context/AppWrapper";
 
@@ -7,7 +7,7 @@ export const useFetchReport = ({ coverKey, incidentDate }) => {
   const [loading, setLoading] = useState(false);
   const { networkId } = useAppContext();
 
-  useEffect(() => {
+  const fetchApi = useCallback(async () => {
     if (!networkId || !coverKey || !incidentDate) {
       return;
     }
@@ -18,6 +18,8 @@ export const useFetchReport = ({ coverKey, incidentDate }) => {
     if (!graphURL) {
       return;
     }
+
+    console.log("fetching");
 
     setLoading(true);
     fetch(graphURL, {
@@ -83,10 +85,15 @@ export const useFetchReport = ({ coverKey, incidentDate }) => {
       });
   }, [coverKey, incidentDate, networkId]);
 
+  useEffect(() => {
+    fetchApi();
+  }, [fetchApi]);
+
   return {
     data: {
       incidentReport: data?.incidentReport,
     },
     loading,
+    refetch: fetchApi,
   };
 };

--- a/src/hooks/useFinalizeIncident.jsx
+++ b/src/hooks/useFinalizeIncident.jsx
@@ -32,7 +32,7 @@ export const useFinalizeIncident = ({ coverKey, incidentDate }) => {
       const args = [coverKey, incidentDate];
       const tx = await invoke(instance, "finalize", {}, notifyError, args);
 
-      txToast.push(tx, {
+      await txToast.push(tx, {
         pending: "Finalizing Incident",
         success: "Finalized Incident Successfully",
         failure: "Could not Finalize Incident",

--- a/src/hooks/useRetryUntilPassed.jsx
+++ b/src/hooks/useRetryUntilPassed.jsx
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+
+export const useRetryUntilPassed = (callback, expected, interval = 1000) => {
+  const [passed, setPassed] = useState(false);
+
+  useEffect(() => {
+    let ignore = false;
+
+    const intervalId = setInterval(() => {
+      const result = callback();
+
+      if (!ignore && result === expected) {
+        clearInterval(intervalId);
+        setPassed(true);
+      }
+    }, interval);
+
+    return () => {
+      ignore = true;
+      clearInterval(intervalId);
+    };
+  }, [callback, expected, interval]);
+
+  return passed;
+};

--- a/src/pages/reporting/[id]/[timestamp]/details.jsx
+++ b/src/pages/reporting/[id]/[timestamp]/details.jsx
@@ -9,7 +9,7 @@ export default function IncidentResolvedCoverPage() {
   const { id: cover_id, timestamp } = router.query;
 
   const coverKey = toBytes32(cover_id);
-  const { data, loading } = useFetchReport({
+  const { data, loading, refetch } = useFetchReport({
     coverKey: coverKey,
     incidentDate: timestamp,
   });
@@ -29,7 +29,10 @@ export default function IncidentResolvedCoverPage() {
       {!data.incidentReport && <p className="text-center">No data found</p>}
 
       {data.incidentReport && (
-        <ReportingDetailsPage incidentReport={data.incidentReport} />
+        <ReportingDetailsPage
+          incidentReport={data.incidentReport}
+          refetchReport={refetch}
+        />
       )}
     </main>
   );

--- a/src/utils/bn.js
+++ b/src/utils/bn.js
@@ -8,6 +8,8 @@ BigNumber.config({
 
 export const ZERO_BI = BigNumber("0");
 
+export const toBN = (x) => new BigNumber(x.toString());
+
 export const hasValue = (x) => {
   return !(!x || !parseFloat(x.toString()));
 };


### PR DESCRIPTION
- Refresh state of reporting details page when timer ends
- Refetch report data from subgraph, when resolved, emergency resolved and finalized. Added a delay of `15 seconds` since subgraph takes some time to update.
- Fix calculation of staking pool tvl. Add bond pool value to TVL(Pool)