### PR TITLE
Allow configuration of unsupported regions

### DIFF
--- a/src/pages/_middleware.js
+++ b/src/pages/_middleware.js
@@ -1,20 +1,22 @@
 import { NextResponse } from "next/server";
 
-/**
- * Unavailable to:
- *
- * United States (US)
- * Guam (GU)
- * American Samoa (AS)
- * Northern Mariana Islands (MP)
- * Puerto Rico (PR)
- * U.S. Virgin Islands (VI)
- * @type Array<string>
- */
-const unavailableTo = ["US", "GU", "AS", "MP", "PR", "VI"];
+/** @type string */
+const regions = process.env.NEXT_PUBLIC_UNSUPPORTED_REGIONS || "";
 
+const unavailableTo = regions.split(",").filter((x) => !!x);
+
+/**
+ *
+ * @param {import("next/server").NextRequest} req
+ * @returns {Promise<Response | undefined> | Response | undefined}
+ */
 export default function geoBlocking(req) {
-  const country = req.geo?.country;
+  const country = req.geo?.country || "";
+
+  if (!country || unavailableTo.length == 0) {
+    return NextResponse.next();
+  }
+
   const unavailable = unavailableTo.indexOf(country) > -1;
   const landingPage = req.nextUrl.clone().pathName === "/unavailable";
 


### PR DESCRIPTION
- Unsupported regions can be now configured through environment variable `NEXT_PUBLIC_UNSUPPORTED_REGIONS`
- Uses 2 letter country code

**Example**

```
NEXT_PUBLIC_UNSUPPORTED_REGIONS=US,GU,AS,MP,PR,VI
```

<details>
<summary><strong>Country Code Examples</strong></summary>

- United States (US)
- Guam (GU)
- American Samoa (AS)
- Northern Mariana Islands (MP)
- Puerto Rico (PR)
- U.S. Virgin Islands (VI)

</details>
