### PR TITLE
updated usePurchasePolicy hook 

### DIFF
--- a/src/components/UI/organisms/cover-form/PurchasePolicyForm.jsx
+++ b/src/components/UI/organisms/cover-form/PurchasePolicyForm.jsx
@@ -43,6 +43,7 @@ export const PurchasePolicyForm = ({ coverKey }) => {
     handleApprove,
     handlePurchase,
     updatingBalance,
+    updatingAllowance,
   } = usePurchasePolicy({
     value,
     coverMonth,
@@ -76,6 +77,8 @@ export const PurchasePolicyForm = ({ coverKey }) => {
   let loadingMessage = "";
   if (updatingFee) {
     loadingMessage = "Fetching...";
+  } else if (updatingAllowance) {
+    loadingMessage = "Fetching Allowance...";
   } else if (updatingBalance) {
     loadingMessage = "Fetching Balance...";
   }

--- a/src/hooks/usePurchasePolicy.jsx
+++ b/src/hooks/usePurchasePolicy.jsx
@@ -46,6 +46,7 @@ export const usePurchasePolicy = ({
     allowance,
     approve,
     refetch: updateAllowance,
+    loading: updatingAllowance,
   } = useERC20Allowance(liquidityTokenAddress);
   const { invoke } = useInvokeMethod();
   const { notifyError } = useErrorNotifier();
@@ -141,7 +142,7 @@ export const usePurchasePolicy = ({
 
     const cleanup = () => {
       setPurchasing(false);
-      updateAllowance();
+      updateAllowance(policyContractAddress);
       updateBalance();
     };
 
@@ -208,6 +209,7 @@ export const usePurchasePolicy = ({
     balance,
     allowance,
     approving,
+    updatingAllowance,
     purchasing,
     canPurchase,
     error,


### PR DESCRIPTION
- fixed updateAllowance function to correctly fetch allowance after purchase action
- This fixes the users seeing "ERC20: transfer amount exceeds allowance" on purchase page