### PR TITLE
Fixed inputfield not accepting 0 after decimal

### DIFF
--- a/src/components/UI/atoms/input/with-trailing-button.jsx
+++ b/src/components/UI/atoms/input/with-trailing-button.jsx
@@ -56,10 +56,19 @@ export const InputWithTrailingButton = ({
           sep.decimal
         }$`
       );
+
+      // regex to identify if there are 0s at the end
+      const endZeroRegex = new RegExp(
+        `^${inputProps.allowNegative ? "-?" : ""}\\d*(\\${
+          sep.thousand
+        }\\d+)*\\${sep.decimal}\\d*0+$`
+      );
+
       if (
         val !== "" &&
         (val.match(incompleteRegex) ||
-          (inputProps.allowNegative && val === "-"))
+          (inputProps.allowNegative && val === "-") ||
+          val.match(endZeroRegex))
       ) {
         return setVal(val);
       }


### PR DESCRIPTION
The inputfield had an issue where we were not able to enter `0` after decimal since locale formatting removed the trailing 0 from the number. The issue is fixed.