### PR TITLE
fixed wrong bond amount in bond info card

### DIFF
--- a/src/components/pages/pools/bond/index.jsx
+++ b/src/components/pages/pools/bond/index.jsx
@@ -93,18 +93,12 @@ const BondPage = () => {
     rightHalf.push({
       title: "Your Bond",
       value: `${
-        formatCurrency(
-          convertFromUnits(info.bondContribution).toString(),
-          tokenSymbol,
-          true
-        ).short
+        formatCurrency(convertFromUnits(info.claimable).toString(), "NPM", true)
+          .short
       }`,
       tooltip: `${
-        formatCurrency(
-          convertFromUnits(info.bondContribution).toString(),
-          tokenSymbol,
-          true
-        ).long
+        formatCurrency(convertFromUnits(info.claimable).toString(), "NPM", true)
+          .long
       }`,
       titleClasses: `mt-7`,
       valueClasses: `text-sm text-9B9B9B mt-1`,


### PR DESCRIPTION
In the Bond info card in the bond  pools page, the `Your Bond` section is updated to show **current claimable amount** instead of **total bonded amount**.