### PR TITLE
VS code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,7 +25,6 @@
         "postcss": "css"
     },
     "editor.tabSize": 2,
-    "javascript.validate.enable": false,
     "javascript.preferences.importModuleSpecifier": "non-relative",
     "cSpell.words": [
         "nosniff"


### PR DESCRIPTION
- removed js validate enable on settings