### PR TITLE
hide withdraw button if npm stake and pod balance is 0

### DIFF
--- a/src/context/AppConstants.jsx
+++ b/src/context/AppConstants.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { registry } from "@neptunemutual/sdk";
 
 import { useNetwork } from "@/src/context/Network";
@@ -46,7 +46,7 @@ export const AppConstantsProvider = ({ children }) => {
     }));
   };
 
-  const getAddressFromApi = async (networkId) => {
+  const getAddressFromApi = useCallback(async (networkId) => {
     try {
       const networkName = NetworkUrlParam[networkId];
       const response = await fetch(
@@ -70,7 +70,7 @@ export const AppConstantsProvider = ({ children }) => {
     } catch (error) {
       console.error(error);
     }
-  };
+  }, []);
 
   useEffect(() => {
     if (!networkId) return;
@@ -87,7 +87,7 @@ export const AppConstantsProvider = ({ children }) => {
     registry.NPMToken.getAddress(networkId, signerOrProvider).then((_addr) =>
       setAddress(_addr, "NPMTokenAddress")
     );
-  }, [account, library, networkId]);
+  }, [account, getAddressFromApi, library, networkId]);
 
   return (
     <AppConstantsContext.Provider

--- a/src/context/Network.jsx
+++ b/src/context/Network.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { useEagerConnect } from "@/lib/connect-wallet/hooks/useEagerConnect";
 import { useInactiveListener } from "@/lib/connect-wallet/hooks/useInactiveListener";
@@ -15,11 +15,7 @@ export function useNetwork() {
 }
 
 export const NetworkProvider = ({ children }) => {
-  const [networkId, setNetworkId] = useState();
-
-  useEffect(() => {
-    setNetworkId(getNetworkId());
-  }, []);
+  const [networkId] = useState(getNetworkId);
 
   return (
     <NetworkContext.Provider value={{ networkId }}>

--- a/src/modules/my-liquidity/details.jsx
+++ b/src/modules/my-liquidity/details.jsx
@@ -152,7 +152,7 @@ export const MyLiquidityCoverPage = () => {
                   </strong>
                 </div>
 
-                {isGreater(myStake, 0) && isGreater(podBalance, 0) && (
+                {isGreater(myStake, "0") && isGreater(podBalance, "0") && (
                   <div className="flex justify-center px-7">
                     <OutlinedButton
                       className="w-full rounded-big"

--- a/src/modules/my-liquidity/details.jsx
+++ b/src/modules/my-liquidity/details.jsx
@@ -13,9 +13,10 @@ import { SeeMoreParagraph } from "@/common/SeeMoreParagraph";
 import { getCoverImgSrc, toBytes32 } from "@/src/helpers/cover";
 import { useMyLiquidityInfo } from "@/src/hooks/provide-liquidity/useMyLiquidityInfo";
 import { CoverProfileInfo } from "@/common/CoverProfileInfo/CoverProfileInfo";
-import { convertFromUnits } from "@/utils/bn";
+import { convertFromUnits, isGreater } from "@/utils/bn";
 import { formatCurrency } from "@/utils/formatter/currency";
 import { ProvideLiquidityForm } from "@/common/LiquidityForms/ProvideLiquidityForm";
+import { useLiquidityFormsContext } from "@/common/LiquidityForms/LiquidityFormsContext";
 import { t, Trans } from "@lingui/macro";
 
 export const MyLiquidityCoverPage = () => {
@@ -34,6 +35,8 @@ export const MyLiquidityCoverPage = () => {
   } = useMyLiquidityInfo({
     coverKey,
   });
+
+  const { myStake, podBalance } = useLiquidityFormsContext();
 
   function onClose() {
     setIsOpen(false);
@@ -83,7 +86,10 @@ export const MyLiquidityCoverPage = () => {
 
               {/* My Liquidity */}
               <HeroStat title={t`My Liquidity`}>
-                {formatCurrency(convertFromUnits(myLiquidity), router.locale).long}
+                {
+                  formatCurrency(convertFromUnits(myLiquidity), router.locale)
+                    .long
+                }
               </HeroStat>
             </div>
           </Container>
@@ -105,13 +111,23 @@ export const MyLiquidityCoverPage = () => {
               <CoverPurchaseResolutionSources coverInfo={coverInfo}>
                 <div
                   className="flex justify-between pt-4 pb-2"
-                  title={formatCurrency(convertFromUnits(totalLiquidity), router.locale).long}
+                  title={
+                    formatCurrency(
+                      convertFromUnits(totalLiquidity),
+                      router.locale
+                    ).long
+                  }
                 >
                   <span className="">
                     <Trans>Total Liquidity:</Trans>
                   </span>
                   <strong className="font-bold text-right">
-                    {formatCurrency(convertFromUnits(totalLiquidity), router.locale).short}
+                    {
+                      formatCurrency(
+                        convertFromUnits(totalLiquidity),
+                        router.locale
+                      ).short
+                    }
                   </strong>
                 </div>
                 <div
@@ -136,14 +152,16 @@ export const MyLiquidityCoverPage = () => {
                   </strong>
                 </div>
 
-                <div className="flex justify-center px-7">
-                  <OutlinedButton
-                    className="w-full rounded-big"
-                    onClick={onOpen}
-                  >
-                    <Trans>Withdraw Liquidity</Trans>
-                  </OutlinedButton>
-                </div>
+                {isGreater(myStake, 0) && isGreater(podBalance, 0) && (
+                  <div className="flex justify-center px-7">
+                    <OutlinedButton
+                      className="w-full rounded-big"
+                      onClick={onOpen}
+                    >
+                      <Trans>Withdraw Liquidity</Trans>
+                    </OutlinedButton>
+                  </div>
+                )}
               </CoverPurchaseResolutionSources>
               <div className="flex justify-end">
                 {isWithdrawalWindowOpen && (

--- a/src/modules/my-policies/PoliciesTabs.jsx
+++ b/src/modules/my-policies/PoliciesTabs.jsx
@@ -7,6 +7,7 @@ import { TabNav } from "@/common/Tab/TabNav";
 import { convertFromUnits } from "@/utils/bn";
 import { formatCurrency } from "@/utils/formatter/currency";
 import { t, Trans } from "@lingui/macro";
+import { useRouter } from "next/router";
 
 const headers = [
   {
@@ -24,6 +25,7 @@ const headers = [
 export const PoliciesTabs = ({ active, children }) => {
   const { data } = useActivePolicies();
   const { totalActiveProtection } = data;
+  const router = useRouter();
 
   return (
     <>
@@ -35,7 +37,12 @@ export const PoliciesTabs = ({ active, children }) => {
 
           {/* Total Active Protection */}
           <HeroStat title="Total Active Protection">
-            {formatCurrency(convertFromUnits(totalActiveProtection), router.locale).long}
+            {
+              formatCurrency(
+                convertFromUnits(totalActiveProtection),
+                router.locale
+              ).long
+            }
           </HeroStat>
         </Container>
 


### PR DESCRIPTION
Network.jsx
 - lazy loading of getNetworkId, cleaner implementation with single rerender effect

AppContainer.jsx
 - fix useEffect dependency warning by enclosing `getAddressFromApi` with useCallback function

modules/my-liquidity
 - hides withdraw button when npm token and pod balance is 0