### PR TITLE
Rename cover info to avoid conflict with ipfs data

### DIFF
--- a/src/common/AcceptRulesForm/AcceptRulesForm.jsx
+++ b/src/common/AcceptRulesForm/AcceptRulesForm.jsx
@@ -5,14 +5,14 @@ import { Trans } from "@lingui/macro";
 import { Alert } from "@/common/Alert/Alert";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useCoverInfoContext } from "@/common/Cover/CoverInfoContext";
+import { useCoverStatsContext } from "@/common/Cover/CoverStatsContext";
 import { safeParseBytes32String } from "@/utils/formatter/bytes32String";
 
 export const AcceptRulesForm = ({ onAccept, children, coverKey }) => {
   const router = useRouter();
   const coverPurchasePage = router.pathname.includes("purchase");
   const [checked, setChecked] = useState(false);
-  const { activeIncidentDate, status } = useCoverInfoContext();
+  const { activeIncidentDate, status } = useCoverStatsContext();
 
   const handleChange = (ev) => {
     setChecked(ev.target.checked);

--- a/src/common/Cover/CoverCard.jsx
+++ b/src/common/Cover/CoverCard.jsx
@@ -8,7 +8,7 @@ import { formatPercent } from "@/utils/formatter/percent";
 import { MULTIPLIER } from "@/src/config/constants";
 import { CardStatusBadge } from "@/common/CardStatusBadge";
 import { Trans } from "@lingui/macro";
-import { useFetchCoverInfo } from "@/src/hooks/useFetchCoverInfo";
+import { useFetchCoverStats } from "@/src/hooks/useFetchCoverStats";
 import { useMyLiquidityInfo } from "@/src/hooks/provide-liquidity/useMyLiquidityInfo";
 import { useRouter } from "next/router";
 import { useCovers } from "@/src/context/Covers";
@@ -22,7 +22,7 @@ export const CoverCard = ({ details }) => {
 
   const imgSrc = getCoverImgSrc({ key });
 
-  const { commitment, status } = useFetchCoverInfo({
+  const { commitment, status } = useFetchCoverStats({
     coverKey: key,
   });
 

--- a/src/common/Cover/CoverStatsContext.jsx
+++ b/src/common/Cover/CoverStatsContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext } from "react";
-import { useFetchCoverInfo } from "@/src/hooks/useFetchCoverInfo";
+import { useFetchCoverStats } from "@/src/hooks/useFetchCoverStats";
 
-const defaultInfo = {
+const defaultStats = {
   activeIncidentDate: "0",
   claimPlatformFee: "0",
   commitment: "0",
@@ -14,9 +14,9 @@ const defaultInfo = {
   totalPoolAmount: "0",
 };
 
-const CoverInfoContext = createContext(defaultInfo);
+const CoverStatsContext = createContext(defaultStats);
 
-export const CoverInfoProvider = ({ coverKey, children }) => {
+export const CoverStatsProvider = ({ coverKey, children }) => {
   const {
     activeIncidentDate,
     claimPlatformFee,
@@ -28,10 +28,10 @@ export const CoverInfoProvider = ({ coverKey, children }) => {
     status,
     totalCommitment,
     totalPoolAmount,
-  } = useFetchCoverInfo({ coverKey });
+  } = useFetchCoverStats({ coverKey });
 
   return (
-    <CoverInfoContext.Provider
+    <CoverStatsContext.Provider
       value={{
         activeIncidentDate,
         claimPlatformFee,
@@ -46,15 +46,15 @@ export const CoverInfoProvider = ({ coverKey, children }) => {
       }}
     >
       {children}
-    </CoverInfoContext.Provider>
+    </CoverStatsContext.Provider>
   );
 };
 
-export function useCoverInfoContext() {
-  const context = useContext(CoverInfoContext);
+export function useCoverStatsContext() {
+  const context = useContext(CoverStatsContext);
   if (context === undefined) {
     throw new Error(
-      "useCoverInfoContext must be used within a CoverInfoContext.Provider"
+      "useCoverStatsContext must be used within a CoverStatsContext.Provider"
     );
   }
   return context;

--- a/src/common/Cover/Purchase/CoverPurchaseResolutionSources.jsx
+++ b/src/common/Cover/Purchase/CoverPurchaseResolutionSources.jsx
@@ -2,11 +2,11 @@ import { OutlinedCard } from "@/common/OutlinedCard/OutlinedCard";
 import { explainInterval } from "@/utils/formatter/interval";
 import Link from "next/link";
 import { Trans } from "@lingui/macro";
-import { useCoverInfoContext } from "@/common/Cover/CoverInfoContext";
+import { useCoverStatsContext } from "@/common/Cover/CoverStatsContext";
 
 export const CoverPurchaseResolutionSources = ({ children, coverInfo }) => {
   const projectName = coverInfo.projectName;
-  const { reportingPeriod } = useCoverInfoContext();
+  const { reportingPeriod } = useCoverStatsContext();
 
   if (!coverInfo.resolutionSources) {
     return null;

--- a/src/common/CoverForm/PurchasePolicyForm.jsx
+++ b/src/common/CoverForm/PurchasePolicyForm.jsx
@@ -22,7 +22,7 @@ import { useToast } from "@/lib/toast/context";
 import { TOAST_DEFAULT_TIMEOUT } from "@/src/config/toast";
 import OpenInNewIcon from "@/icons/OpenInNewIcon";
 import { t, Trans } from "@lingui/macro";
-import { useCoverInfoContext } from "@/common/Cover/CoverInfoContext";
+import { useCoverStatsContext } from "@/common/Cover/CoverStatsContext";
 import BigNumber from "bignumber.js";
 import { safeParseBytes32String } from "@/utils/formatter/bytes32String";
 
@@ -32,7 +32,7 @@ export const PurchasePolicyForm = ({ coverKey }) => {
   const [coverMonth, setCoverMonth] = useState();
   const { liquidityTokenAddress } = useAppConstants();
   const liquidityTokenSymbol = useTokenSymbol(liquidityTokenAddress);
-  const { totalCommitment, totalPoolAmount } = useCoverInfoContext();
+  const { totalCommitment, totalPoolAmount } = useCoverStatsContext();
 
   const availableLiquidity = convertFromUnits(
     BigNumber(totalPoolAmount.toString()).minus(totalCommitment.toString())
@@ -65,7 +65,7 @@ export const PurchasePolicyForm = ({ coverKey }) => {
   });
 
   const { isUserWhitelisted, requiresWhitelist, activeIncidentDate, status } =
-    useCoverInfoContext();
+    useCoverStatsContext();
 
   const ViewToastPoliciesLink = () => (
     <Link href="/my-policies/active">

--- a/src/common/CoverProfileInfo/CoverProfileInfo.jsx
+++ b/src/common/CoverProfileInfo/CoverProfileInfo.jsx
@@ -1,4 +1,4 @@
-import { useCoverInfoContext } from "@/common/Cover/CoverInfoContext";
+import { useCoverStatsContext } from "@/common/Cover/CoverStatsContext";
 import { SocialIconLinks } from "@/common/CoverProfileInfo/SocialIconLinks";
 import { ProjectImage } from "./ProjectImage";
 import { ProjectName } from "./ProjectName";
@@ -6,7 +6,7 @@ import { ProjectStatusIndicator } from "./ProjectStatusIndicator";
 import { ProjectWebsiteLink } from "./ProjectWebsiteLink";
 
 export const CoverProfileInfo = ({ imgSrc, projectName, links, coverKey }) => {
-  const { status, activeIncidentDate } = useCoverInfoContext();
+  const { status, activeIncidentDate } = useCoverStatsContext();
 
   return (
     <div className="flex">

--- a/src/common/LiquidityForms/ProvideLiquidityForm.jsx
+++ b/src/common/LiquidityForms/ProvideLiquidityForm.jsx
@@ -27,7 +27,7 @@ import { useToast } from "@/lib/toast/context";
 import { TOAST_DEFAULT_TIMEOUT } from "@/src/config/toast";
 import OpenInNewIcon from "@/icons/OpenInNewIcon";
 import { t, Trans } from "@lingui/macro";
-import { useCoverInfoContext } from "@/common/Cover/CoverInfoContext";
+import { useCoverStatsContext } from "@/common/Cover/CoverStatsContext";
 import { safeParseBytes32String } from "@/utils/formatter/bytes32String";
 
 export const ProvideLiquidityForm = ({ coverKey, info }) => {
@@ -43,7 +43,7 @@ export const ProvideLiquidityForm = ({ coverKey, info }) => {
 
   const toast = useToast();
 
-  const { status, activeIncidentDate } = useCoverInfoContext();
+  const { status, activeIncidentDate } = useCoverStatsContext();
   const {
     lqTokenBalance,
     npmBalance,

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -48,8 +48,10 @@ export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL
 export const PRICING_URL = `${API_BASE_URL}pricing/{networkId}`;
 export const POOL_INFO_URL = `${API_BASE_URL}protocol/staking-pools/info/{type}/{networkId}/{key}/{account}`;
 export const UNSTAKE_INFO_URL = `${API_BASE_URL}protocol/consensus/unstake-info/{networkId}/{coverKey}/{account}/{incidentDate}`;
-
 export const BOND_INFO_URL = `${API_BASE_URL}protocol/bond/info/{networkId}/{account}`;
+export const GET_CONTRACTS_INFO_URL = `${API_BASE_URL}protocol/contracts/{networkName}`;
+export const COVER_STATS_URL = `${API_BASE_URL}protocol/cover/info/{networkId}/{coverKey}/{account}`;
+export const VAULT_INFO_URL = `${API_BASE_URL}protocol/vault/info/{networkId}/{coverKey}/{account}`;
 
 export const FAUCET_URL = "https://faucet.neptunemutual.com/";
 export const LEADERBOARD_URL = "https://leaderboard.neptunemutual.com/";
@@ -73,8 +75,3 @@ export const NetworkUrlParam = {
   1: "",
   3: "ropsten",
 };
-
-export const GET_CONTRACTS_INFO_URL = `${API_BASE_URL}protocol/contracts/{networkName}`;
-export const COVER_INFO_URL = `${API_BASE_URL}protocol/cover/info/{networkId}/{coverKey}/{account}`;
-export const VAULT_INFO_URL = `${API_BASE_URL}protocol/vault/info/{networkId}/{coverKey}/{account}`;
-

--- a/src/helpers/cover.js
+++ b/src/helpers/cover.js
@@ -1,5 +1,11 @@
 import { parseBytes32String } from "@ethersproject/strings";
 
+/**
+ * 
+ * @param {Object} [coverData]
+ * @param {string} coverData.key
+ * @returns 
+ */
 export const getCoverImgSrc = ({ key } = { key: "" }) => {
   try {
     return `/images/covers/${parseBytes32String(key)}.svg`;

--- a/src/hooks/useFetchCoverStats.jsx
+++ b/src/hooks/useFetchCoverStats.jsx
@@ -5,10 +5,10 @@ import { getReplacedString } from "@/utils/string";
 import {
   ADDRESS_ONE,
   CoverStatus,
-  COVER_INFO_URL,
+  COVER_STATS_URL,
 } from "@/src/config/constants";
 
-const defaultInfo = {
+const defaultStats = {
   activeIncidentDate: "0",
   claimPlatformFee: "0",
   commitment: "0",
@@ -21,18 +21,18 @@ const defaultInfo = {
   totalPoolAmount: "0",
 };
 
-export const useFetchCoverInfo = ({ coverKey }) => {
-  const [info, setInfo] = useState(defaultInfo);
+export const useFetchCoverStats = ({ coverKey }) => {
+  const [info, setInfo] = useState(defaultStats);
   const { account } = useWeb3React();
   const { networkId } = useNetwork();
 
   useEffect(() => {
-    async function fetchCoverInfo() {
+    async function exec() {
       if (!networkId || !coverKey) return;
 
       try {
         const response = await fetch(
-          getReplacedString(COVER_INFO_URL, {
+          getReplacedString(COVER_STATS_URL, {
             networkId,
             coverKey,
             account: account || ADDRESS_ONE,
@@ -72,7 +72,8 @@ export const useFetchCoverInfo = ({ coverKey }) => {
         console.error(error);
       }
     }
-    fetchCoverInfo();
+
+    exec();
   }, [account, coverKey, networkId]);
 
   return info;

--- a/src/modules/cover/purchase/index.jsx
+++ b/src/modules/cover/purchase/index.jsx
@@ -17,7 +17,7 @@ import { PurchasePolicyForm } from "@/common/CoverForm/PurchasePolicyForm";
 import { formatCurrency } from "@/utils/formatter/currency";
 import { t, Trans } from "@lingui/macro";
 import { useMyLiquidityInfo } from "@/src/hooks/provide-liquidity/useMyLiquidityInfo";
-import { useCoverInfoContext } from "@/common/Cover/CoverInfoContext";
+import { useCoverStatsContext } from "@/common/Cover/CoverStatsContext";
 import BigNumber from "bignumber.js";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
@@ -28,7 +28,7 @@ export const CoverPurchaseDetailsPage = () => {
   const coverKey = safeFormatBytes32String(cover_id);
   const { coverInfo } = useCoverInfo(coverKey);
 
-  const { totalPoolAmount, totalCommitment } = useCoverInfoContext();
+  const { totalPoolAmount, totalCommitment } = useCoverStatsContext();
   const availableLiquidity = convertFromUnits(
     BigNumber(totalPoolAmount.toString()).minus(totalCommitment.toString())
   ).toString();

--- a/src/modules/my-policies/PolicyCard.jsx
+++ b/src/modules/my-policies/PolicyCard.jsx
@@ -9,14 +9,14 @@ import DateLib from "@/lib/date/DateLib";
 import { isGreater } from "@/utils/bn";
 import { ReportStatus } from "@/src/config/constants";
 import { CardStatusBadge } from "@/common/CardStatusBadge";
-import { useFetchCoverInfo } from "@/src/hooks/useFetchCoverInfo";
+import { useFetchCoverStats } from "@/src/hooks/useFetchCoverStats";
 
 export const PolicyCard = ({ policyInfo }) => {
   const { cover, cxToken } = policyInfo;
 
   const coverKey = cover.id;
   const { coverInfo } = useCoverInfo(coverKey);
-  const { status: currentStatus } = useFetchCoverInfo({ coverKey });
+  const { status: currentStatus } = useFetchCoverStats({ coverKey });
 
   const validityStartsAt = cxToken.creationDate || "0";
   const validityEndsAt = cxToken.expiryDate || "0";

--- a/src/modules/reporting/active/ActiveReportingCard.jsx
+++ b/src/modules/reporting/active/ActiveReportingCard.jsx
@@ -12,13 +12,13 @@ import { convertFromUnits, toBN } from "@/utils/bn";
 import { CardStatusBadge } from "@/common/CardStatusBadge";
 import { Trans } from "@lingui/macro";
 import { useMyLiquidityInfo } from "@/src/hooks/provide-liquidity/useMyLiquidityInfo";
-import { useFetchCoverInfo } from "@/src/hooks/useFetchCoverInfo";
+import { useFetchCoverStats } from "@/src/hooks/useFetchCoverStats";
 import { useRouter } from "next/router";
 
 export const ActiveReportingCard = ({ coverKey, incidentDate }) => {
   const { coverInfo } = useCoverInfo(coverKey);
   const { info: liquidityInfo } = useMyLiquidityInfo({ coverKey });
-  const { commitment, status } = useFetchCoverInfo({
+  const { commitment, status } = useFetchCoverStats({
     coverKey,
   });
   const router = useRouter();

--- a/src/pages/cover/[cover_id]/add-liquidity/index.jsx
+++ b/src/pages/cover/[cover_id]/add-liquidity/index.jsx
@@ -5,7 +5,7 @@ import { ComingSoon } from "@/common/ComingSoon";
 import { isFeatureEnabled } from "@/src/config/environment";
 import { LiquidityFormsProvider } from "@/common/LiquidityForms/LiquidityFormsContext";
 import { useRouter } from "next/router";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
 export function getServerSideProps() {
@@ -35,11 +35,11 @@ export default function CoverAddLiquidityDetails({ disabled }) {
         />
       </Head>
 
-      <CoverInfoProvider coverKey={coverKey}>
+      <CoverStatsProvider coverKey={coverKey}>
         <LiquidityFormsProvider coverKey={coverKey}>
           <CoverAddLiquidityDetailsPage />
         </LiquidityFormsProvider>
-      </CoverInfoProvider>
+      </CoverStatsProvider>
     </>
   );
 }

--- a/src/pages/cover/[cover_id]/purchase/index.jsx
+++ b/src/pages/cover/[cover_id]/purchase/index.jsx
@@ -1,6 +1,6 @@
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 
 import { CoverPurchaseDetailsPage } from "@/src/modules/cover/purchase";
 import { ComingSoon } from "@/common/ComingSoon";
@@ -34,9 +34,9 @@ export default function CoverPurchaseDetails({ disabled }) {
         />
       </Head>
 
-      <CoverInfoProvider coverKey={coverKey}>
+      <CoverStatsProvider coverKey={coverKey}>
         <CoverPurchaseDetailsPage />
-      </CoverInfoProvider>
+      </CoverStatsProvider>
     </>
   );
 }

--- a/src/pages/my-liquidity/[cover_id]/index.jsx
+++ b/src/pages/my-liquidity/[cover_id]/index.jsx
@@ -4,7 +4,7 @@ import { ComingSoon } from "@/common/ComingSoon";
 import { isFeatureEnabled } from "@/src/config/environment";
 import { LiquidityFormsProvider } from "@/common/LiquidityForms/LiquidityFormsContext";
 import { useRouter } from "next/router";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
 export function getServerSideProps() {
@@ -34,11 +34,11 @@ export default function MyLiquidityCover({ disabled }) {
         />
       </Head>
 
-      <CoverInfoProvider coverKey={coverKey}>
+      <CoverStatsProvider coverKey={coverKey}>
         <LiquidityFormsProvider coverKey={coverKey}>
           <MyLiquidityCoverPage />
         </LiquidityFormsProvider>
-      </CoverInfoProvider>
+      </CoverStatsProvider>
     </main>
   );
 }

--- a/src/pages/my-policies/[cover_id]/[timestamp]/claim.jsx
+++ b/src/pages/my-policies/[cover_id]/[timestamp]/claim.jsx
@@ -15,7 +15,7 @@ import { useFetchReportsByKeyAndDate } from "@/src/hooks/useFetchReportsByKeyAnd
 import { Alert } from "@/common/Alert/Alert";
 import { isFeatureEnabled } from "@/src/config/environment";
 import { t, Trans } from "@lingui/macro";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 import { usePagination } from "@/src/hooks/usePagination";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
@@ -51,7 +51,7 @@ export default function ClaimPolicy({ disabled }) {
   }
 
   return (
-    <CoverInfoProvider coverKey={coverKey}>
+    <CoverStatsProvider coverKey={coverKey}>
       <main>
         <Head>
           <title>Neptune Mutual Covers</title>
@@ -133,6 +133,6 @@ export default function ClaimPolicy({ disabled }) {
           />
         </Container>
       </main>
-    </CoverInfoProvider>
+    </CoverStatsProvider>
   );
 }

--- a/src/pages/reporting/[id]/[timestamp]/details.jsx
+++ b/src/pages/reporting/[id]/[timestamp]/details.jsx
@@ -5,7 +5,7 @@ import { ReportingDetailsPage } from "@/src/modules/reporting/details";
 import { ComingSoon } from "@/common/ComingSoon";
 import { isFeatureEnabled } from "@/src/config/environment";
 import { Trans } from "@lingui/macro";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
 export function getServerSideProps() {
@@ -31,7 +31,7 @@ export default function IncidentResolvedCoverPage({ disabled }) {
   }
 
   return (
-    <CoverInfoProvider coverKey={coverKey}>
+    <CoverStatsProvider coverKey={coverKey}>
       <main>
         <Head>
           <title>Neptune Mutual Covers</title>
@@ -60,6 +60,6 @@ export default function IncidentResolvedCoverPage({ disabled }) {
           />
         )}
       </main>
-    </CoverInfoProvider>
+    </CoverStatsProvider>
   );
 }

--- a/src/pages/reporting/[id]/[timestamp]/dispute.jsx
+++ b/src/pages/reporting/[id]/[timestamp]/dispute.jsx
@@ -11,7 +11,7 @@ import { isGreater } from "@/utils/bn";
 import { ComingSoon } from "@/common/ComingSoon";
 import { isFeatureEnabled } from "@/src/config/environment";
 import { Trans } from "@lingui/macro";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
 export function getServerSideProps() {
@@ -46,7 +46,7 @@ export default function DisputeFormPage({ disabled }) {
   }
 
   return (
-    <CoverInfoProvider coverKey={coverKey}>
+    <CoverStatsProvider coverKey={coverKey}>
       <main>
         <Head>
           <title>Neptune Mutual Covers</title>
@@ -93,6 +93,6 @@ export default function DisputeFormPage({ disabled }) {
           </div>
         )}
       </main>
-    </CoverInfoProvider>
+    </CoverStatsProvider>
   );
 }

--- a/src/pages/reporting/[id]/new.jsx
+++ b/src/pages/reporting/[id]/new.jsx
@@ -8,7 +8,7 @@ import { useEffect, useState } from "react";
 import { useFetchCoverActiveReportings } from "@/src/hooks/useFetchCoverActiveReportings";
 import { ComingSoon } from "@/common/ComingSoon";
 import { isFeatureEnabled } from "@/src/config/environment";
-import { CoverInfoProvider } from "@/common/Cover/CoverInfoContext";
+import { CoverStatsProvider } from "@/common/Cover/CoverStatsContext";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 
 export function getServerSideProps() {
@@ -57,7 +57,7 @@ export default function ReportingNewCoverPage({ disabled }) {
   }
 
   return (
-    <CoverInfoProvider coverKey={coverKey}>
+    <CoverStatsProvider coverKey={coverKey}>
       <main>
         <Head>
           <title>Neptune Mutual Covers</title>
@@ -80,6 +80,6 @@ export default function ReportingNewCoverPage({ disabled }) {
           />
         )}
       </main>
-    </CoverInfoProvider>
+    </CoverStatsProvider>
   );
 }


### PR DESCRIPTION
- Reserving **cover info** for the ipfs data of the cover added by cover creator contains `coverName`, `projectName`, `tags`, `about`, `rules`, `links`, `pricingFloor`, `pricingCeiling`, etc.,
- Using **cover stats** for the data such as `activeIncidentDate`, `claimPlatformFee`, `commitment`, `reporterCommission`, `reportingPeriod`, `totalCommitment`, `totalPoolAmount`, etc.,