### PR TITLE
Fixed unstake error

### DIFF
--- a/src/hooks/useUnstakeReportingStake.jsx
+++ b/src/hooks/useUnstakeReportingStake.jsx
@@ -1,11 +1,9 @@
-import { Contract } from "@ethersproject/contracts";
-
 import { getProviderOrSigner } from "@/lib/connect-wallet/utils/web3";
 import { useNetwork } from "@/src/context/Network";
 import { useAuthValidation } from "@/src/hooks/useAuthValidation";
 import { useErrorNotifier } from "@/src/hooks/useErrorNotifier";
 import { useTxToast } from "@/src/hooks/useTxToast";
-import { registry } from "@neptunemutual/sdk";
+import { registry, utils } from "@neptunemutual/sdk";
 import { useWeb3React } from "@web3-react/core";
 import { useCallback, useEffect, useState } from "react";
 import { useInvokeMethod } from "@/src/hooks/useInvokeMethod";
@@ -152,7 +150,8 @@ export const useUnstakeReportingStake = ({
         cleanup();
       };
 
-      const args = [coverKey, productKey, incidentDate];
+      const _productKey = productKey ?? utils.keyUtil.toBytes32("");
+      const args = [coverKey, _productKey, incidentDate];
       invoke({
         instance: resolutionContract,
         methodName: "unstake",
@@ -185,14 +184,8 @@ export const useUnstakeReportingStake = ({
 
     try {
       const signerOrProvider = getProviderOrSigner(library, account, networkId);
-      const resolutionContractAddress = await registry.Resolution.getAddress(
+      const resolutionContract = await registry.Resolution.getInstance(
         networkId,
-        signerOrProvider
-      );
-
-      const resolutionContract = new Contract(
-        resolutionContractAddress,
-        ["function unstakeWithClaim(bytes32, uint256)"],
         signerOrProvider
       );
 
@@ -214,8 +207,8 @@ export const useUnstakeReportingStake = ({
         cleanup();
       };
 
-      const productKey = null;
-      const args = [coverKey, productKey, incidentDate];
+      const _productKey = productKey ?? utils.keyUtil.toBytes32("");
+      const args = [coverKey, _productKey, incidentDate];
       invoke({
         instance: resolutionContract,
         methodName: "unstakeWithClaim",


### PR DESCRIPTION
- Used `resolutionContract` instance from the sdk instead of `Contract` class of `ethersjs`
- Added fallback zero address(`utils.keyUtil.toBytes32("")`) to product key in case of `null`