### PR TITLE
added condition if already provide liquidity let user to enter 0

### DIFF
--- a/src/common/LiquidityForms/ProvideLiquidityForm.jsx
+++ b/src/common/LiquidityForms/ProvideLiquidityForm.jsx
@@ -92,10 +92,9 @@ export const ProvideLiquidityForm = ({ coverKey, info }) => {
       setNpmErrorMsg(t`Insufficient Stake`);
     } else if (
       npmValue &&
+      !isEqualTo(requiredStake, "0") &&
       isEqualTo(convertToUnits(npmValue, npmTokenDecimals), "0")
     ) {
-      // TODO: Remove once protocol is fixed, if user already staked the `minStakeToAddLiquidity`,
-      // then user should be able to provide ZERO for this input.
       setNpmErrorMsg(t`Please specify an amount`);
     } else if (
       npmValue &&


### PR DESCRIPTION
- While providing liquidity
  - added condition to determine if the user has previously provided adequate liquidity
  - if found, allow the user to enter 0 as token stake.