### PR TITLE
Refactored to get the active reportings of a cover

### DIFF
--- a/src/common/LiquidityForms/ProvideLiquidityForm.jsx
+++ b/src/common/LiquidityForms/ProvideLiquidityForm.jsx
@@ -24,13 +24,9 @@ import { useLiquidityFormsContext } from "@/common/LiquidityForms/LiquidityForms
 import { t, Trans } from "@lingui/macro";
 import { safeParseBytes32String } from "@/utils/formatter/bytes32String";
 import { BackButton } from "@/common/BackButton/BackButton";
+import { useCoverActiveReportings } from "@/src/hooks/useCoverActiveReportings";
 
-export const ProvideLiquidityForm = ({
-  coverKey,
-  info,
-  latestIncident,
-  isDiversified,
-}) => {
+export const ProvideLiquidityForm = ({ coverKey, info, isDiversified }) => {
   const [lqValue, setLqValue] = useState("");
   const [npmValue, setNPMValue] = useState("");
   const router = useRouter();
@@ -84,6 +80,8 @@ export const ProvideLiquidityForm = ({
     value: lqValue,
     podAddress: vaultTokenAddress,
   });
+
+  const { data: activeReportings } = useCoverActiveReportings({ coverKey });
 
   const requiredStake = toBN(minStakeToAddLiquidity).minus(myStake).toString();
 
@@ -154,17 +152,22 @@ export const ProvideLiquidityForm = ({
   };
 
   const hasBothAllowances = hasLqTokenAllowance && hasNPMTokenAllowance;
-  const status = latestIncident?.status;
-  const incidentLink = isDiversified
-    ? `/reporting/${safeParseBytes32String(coverKey)}/product/${
-        latestIncident?.productKey
-      }/${latestIncident?.incidentDate}/details`
-    : `/reporting/${safeParseBytes32String(coverKey)}/${
-        latestIncident?.incidentDate
-      }/details`;
 
-  if (latestIncident?.status !== "Normal") {
-    return (
+  if (activeReportings.length > 0) {
+    const status = activeReportings[0].status;
+    const incidentDate = activeReportings[0].incidentDate;
+    const cover_id = safeParseBytes32String(coverKey);
+
+    const incidentLink = `/reporting/${cover_id}/${incidentDate}/details`;
+
+    return isDiversified ? (
+      <Alert>
+        <Trans>
+          Cannot add liquidity, as one of the product&apos;s status is not
+          normal
+        </Trans>
+      </Alert>
+    ) : (
       <Alert>
         <Trans>Cannot add liquidity, since the cover status is</Trans>{" "}
         <Link href={incidentLink}>

--- a/src/hooks/useCalculateLiquidity.jsx
+++ b/src/hooks/useCalculateLiquidity.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useWeb3React } from "@web3-react/core";
 
 import { convertToUnits, isValidNumber } from "@/utils/bn";
@@ -9,9 +9,10 @@ import { useDebounce } from "@/src/hooks/useDebounce";
 import { useInvokeMethod } from "@/src/hooks/useInvokeMethod";
 import { useErrorNotifier } from "@/src/hooks/useErrorNotifier";
 import { t } from "@lingui/macro";
+import { useMountedState } from "@/src/hooks/useMountedState";
 
 export const useCalculateLiquidity = ({ coverKey, podAmount }) => {
-  const mountedRef = useRef(false);
+  const isMounted = useMountedState();
   const { library, account } = useWeb3React();
   const { networkId } = useNetwork();
 
@@ -53,7 +54,7 @@ export const useCalculateLiquidity = ({ coverKey, podAmount }) => {
       const onTransactionResult = (result) => {
         const liquidityAmount = result;
 
-        if (!mountedRef.current) return;
+        if (!isMounted()) return;
         setReceiveAmount(liquidityAmount);
         cleanup();
       };
@@ -86,19 +87,14 @@ export const useCalculateLiquidity = ({ coverKey, podAmount }) => {
     coverKey,
     debouncedValue,
     invoke,
+    isMounted,
     library,
     networkId,
     notifyError,
   ]);
 
   useEffect(() => {
-    mountedRef.current = true;
-
     calculateLiquidity();
-
-    return () => {
-      mountedRef.current = false;
-    };
   }, [calculateLiquidity]);
 
   return {

--- a/src/hooks/useCoverActiveReportings.jsx
+++ b/src/hooks/useCoverActiveReportings.jsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+import { useQuery } from "@/src/hooks/useQuery";
+
+const getQuery = (coverKey) => {
+  return `
+  {
+    incidentReports(where: {
+      coverKey: "${coverKey}"
+      finalized: false
+    }) {
+      id
+      status
+      productKey
+      incidentDate
+    }
+  }
+  `;
+};
+
+export const useCoverActiveReportings = ({ coverKey }) => {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const { data: graphData, refetch } = useQuery();
+
+  useEffect(() => {
+    let ignore = false;
+
+    if (!graphData || ignore) return;
+    setData(graphData.incidentReports);
+
+    return () => {
+      ignore = true;
+    };
+  }, [graphData]);
+
+  useEffect(() => {
+    setLoading(true);
+
+    refetch(getQuery(coverKey))
+      .catch((err) => {
+        console.error(err);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, [coverKey, refetch]);
+
+  return {
+    data,
+    loading,
+  };
+};

--- a/src/hooks/useFetchCoverProductActiveReportings.jsx
+++ b/src/hooks/useFetchCoverProductActiveReportings.jsx
@@ -19,7 +19,10 @@ const getQuery = (coverKey, productKey) => {
   `;
 };
 
-export const useFetchCoverActiveReportings = ({ coverKey, productKey }) => {
+export const useFetchCoverProductActiveReportings = ({
+  coverKey,
+  productKey,
+}) => {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(false);
 

--- a/src/hooks/useMountedState.jsx
+++ b/src/hooks/useMountedState.jsx
@@ -1,0 +1,18 @@
+import { useEffect, useRef, useCallback } from "react";
+
+// returns a function that when called will
+// return `true` if the component is mounted
+export const useMountedState = () => {
+  const mountedRef = useRef(false);
+  const isMounted = useCallback(() => mountedRef.current, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  return isMounted;
+};

--- a/src/modules/cover/add-liquidity/index.jsx
+++ b/src/modules/cover/add-liquidity/index.jsx
@@ -67,6 +67,7 @@ export const CoverAddLiquidityDetailsPage = () => {
             ) : (
               <CoverProfileInfo
                 coverKey={coverKey}
+                productKey={productKey}
                 imgSrc={imgSrc}
                 projectName={coverInfo?.infoObj.coverName}
                 links={coverInfo?.infoObj.links}
@@ -93,7 +94,6 @@ export const CoverAddLiquidityDetailsPage = () => {
                   coverKey={coverKey}
                   info={info}
                   isDiversified={isDiversified}
-                  latestIncident={coverInfo?.latestIncident}
                 />
               </div>
             ) : (

--- a/src/modules/my-liquidity/details.jsx
+++ b/src/modules/my-liquidity/details.jsx
@@ -106,7 +106,6 @@ export const MyLiquidityCoverPage = () => {
                   coverKey={coverKey}
                   info={info}
                   isDiversified={isDiversified}
-                  latestIncident={coverInfo?.latestIncident}
                 />
               </div>
             </div>

--- a/src/modules/reporting/new/index.jsx
+++ b/src/modules/reporting/new/index.jsx
@@ -5,7 +5,7 @@ import { Trans } from "@lingui/macro";
 import { CoverReportingRules } from "@/src/modules/reporting/CoverReportingRules";
 import { NewIncidentReportForm } from "@/src/modules/reporting/NewIncidentReportForm";
 import { ReportingHero } from "@/src/modules/reporting/ReportingHero";
-import { useFetchCoverActiveReportings } from "@/src/hooks/useFetchCoverActiveReportings";
+import { useFetchCoverProductActiveReportings } from "@/src/hooks/useFetchCoverProductActiveReportings";
 import { safeFormatBytes32String } from "@/utils/formatter/bytes32String";
 import { useCoverOrProductData } from "@/src/hooks/useCoverOrProductData";
 import { isValidProduct } from "@/src/helpers/cover";
@@ -21,7 +21,7 @@ export function NewIncidentReportPage() {
     coverKey: coverKey,
     productKey: productKey,
   });
-  const { data: activeReportings } = useFetchCoverActiveReportings({
+  const { data: activeReportings } = useFetchCoverProductActiveReportings({
     coverKey,
     productKey,
   });

--- a/src/services/covers-products/index.js
+++ b/src/services/covers-products/index.js
@@ -1,6 +1,5 @@
 import { getParsedCoverInfo, getParsedProductInfo } from "@/src/helpers/cover";
 import { getSubgraphData } from "@/src/services/subgraph";
-import { ReportStatus } from "@/src/config/constants";
 
 export async function getCoverData(networkId, coverKey) {
   const data = await getSubgraphData(
@@ -19,23 +18,12 @@ export async function getCoverData(networkId, coverKey) {
       ipfsHash
       ipfsData
     }
-    incidentReports (
-      first: 1
-      orderBy: "finalized"
-    ) {
-      id
-      status
-      incidentDate
-      productKey
-      finalized
-    }
   }
 }`
   );
 
   if (!data) return null;
 
-  const latestIncident = data?.cover?.incidentReports?.[0];
   const products = await Promise.all(
     data.cover.products.map(async (product) => ({
       id: product.id,
@@ -55,12 +43,6 @@ export async function getCoverData(networkId, coverKey) {
     ipfsData: data.cover.ipfsData,
     infoObj: await getParsedCoverInfo(data.cover.ipfsData, data.cover.ipfsHash),
     products: products,
-    latestIncident: {
-      ...(latestIncident || {}),
-      status: latestIncident?.finalized
-        ? "Normal"
-        : ReportStatus[latestIncident.status],
-    },
   };
 }
 
@@ -80,16 +62,6 @@ export async function getCoverProductData(networkId, coverKey, productKey) {
       coverKey
       ipfsHash
       ipfsData
-      incidentReports (
-        first: 1
-        orderBy: "finalized"
-      ) {
-        id
-        status
-        incidentDate
-        productKey
-        finalized
-      }
     }
   }
 }`
@@ -97,7 +69,6 @@ export async function getCoverProductData(networkId, coverKey, productKey) {
 
   if (!data) return null;
 
-  const latestIncident = data?.product?.cover?.incidentReports?.[0];
   return {
     id: data.product.id,
     coverKey: data.product.coverKey,
@@ -118,12 +89,6 @@ export async function getCoverProductData(networkId, coverKey, productKey) {
         data.product.cover.ipfsData,
         data.product.cover.ipfsHash
       ),
-      latestIncident: {
-        ...(latestIncident || {}),
-        status: latestIncident?.finalized
-          ? "Normal"
-          : ReportStatus[latestIncident.status],
-      },
     },
   };
 }


### PR DESCRIPTION
- Added `useMountedState` hook
- Refactored `useQuery` to use `getSubgraphData` function
- Renamed `useFetchCoverActiveReportings` to `useFetchCoverProductActiveReportings`
- Added `useCoverActiveReportings` which returns the reports which are not finalized for a specific `coverKey` (Dedicated or Diversified). For diversified covers, all the reports returned will be of the individual products