### PR TITLE
Fix UI months on purchase policy claim expiry

### DIFF
--- a/src/common/CoverForm/PurchasePolicyForm.jsx
+++ b/src/common/CoverForm/PurchasePolicyForm.jsx
@@ -95,16 +95,16 @@ export const PurchasePolicyForm = ({ coverKey, productKey }) => {
   };
 
   const now = new Date();
-  const day = now.getDate();
+  const day = now.getUTCDate();
   let coverPeriodLabels = [];
   let months = "";
   for (let i = 0; i < 3; i++) {
     if (day >= 25) {
       // if current date is greater than or equal to 25th
       // we add another month
-      months = monthNames[(now.getMonth() + i + 1) % 12];
+      months = monthNames[(now.getUTCMonth() + i + 1) % 12];
     } else {
-      months = monthNames[(now.getMonth() + i) % 12];
+      months = monthNames[(now.getUTCMonth() + i) % 12];
     }
     coverPeriodLabels.push(months);
   }

--- a/src/common/CoverForm/PurchasePolicyForm.jsx
+++ b/src/common/CoverForm/PurchasePolicyForm.jsx
@@ -95,11 +95,20 @@ export const PurchasePolicyForm = ({ coverKey, productKey }) => {
   };
 
   const now = new Date();
-  const coverPeriodLabels = [
-    monthNames[(now.getMonth() + 0) % 12],
-    monthNames[(now.getMonth() + 1) % 12],
-    monthNames[(now.getMonth() + 2) % 12],
-  ];
+  const day = now.getDate();
+  let coverPeriodLabels = [];
+  let months = "";
+  for (let i = 0; i < 3; i++) {
+    if (day >= 25) {
+      // if current date is greater than or equal to 25th
+      // we add another month
+      months = monthNames[(now.getMonth() + i + 1) % 12];
+    } else {
+      months = monthNames[(now.getMonth() + i) % 12];
+    }
+    coverPeriodLabels.push(months);
+  }
+
   let loadingMessage = "";
   if (updatingFee) {
     loadingMessage = t`Fetching...`;


### PR DESCRIPTION
- fixed ui months on purchase policy when selecting month names. if the current date is greater than or equal to the 25th of the month. we add another month on the claim expiry