### PR TITLE
Added tests to hooks

### DIFF
--- a/src/hooks/__tests__/useFetchCoverProductActiveReportings.test.jsx
+++ b/src/hooks/__tests__/useFetchCoverProductActiveReportings.test.jsx
@@ -1,0 +1,73 @@
+import { useFetchCoverProductActiveReportings } from "@/src/hooks/useFetchCoverProductActiveReportings";
+
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFetchCoverProductActiveReportings", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+
+  mockFn.useNetwork();
+  mockFn.getGraphURL();
+  mockFn.getNetworkId();
+
+  const args = [
+    {
+      coverKey:
+        "0x7072696d65000000000000000000000000000000000000000000000000000000",
+      productKey:
+        "0x6161766500000000000000000000000000000000000000000000000000000000",
+    },
+  ];
+
+  test("should return default value", async () => {
+    const mockData = { data: {} };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFetchCoverProductActiveReportings,
+      args
+    );
+
+    expect(result.data).toEqual([]);
+    expect(result.loading).toBeFalsy();
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return correct value as returned from api", async () => {
+    const mockData = {
+      data: { incidentReports: { id: "1", reportedOn: new Date().getTime() } },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFetchCoverProductActiveReportings,
+      args,
+      true
+    );
+
+    expect(result.data).toEqual(mockData.data.incidentReports);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should log error if api error occurs", async () => {
+    mockFn.fetch(false);
+    mock(); // mocking console.error
+
+    await renderHookWrapper(useFetchCoverProductActiveReportings, args, true);
+
+    expect(mockFunction).toHaveBeenCalled();
+
+    restore();
+    mockFn.fetch().unmock();
+  });
+
+  test("should return if no product key & cover key available", async () => {
+    const { result } = await renderHookWrapper(
+      useFetchCoverProductActiveReportings,
+      [{ coverKey: "", productKey: "" }]
+    );
+
+    expect(result.data).toEqual([]);
+  });
+});

--- a/src/hooks/__tests__/useFetchCoverPurchasedEvent.test.jsx
+++ b/src/hooks/__tests__/useFetchCoverPurchasedEvent.test.jsx
@@ -1,0 +1,111 @@
+import DateLib from "@/lib/date/DateLib";
+import {
+  storePurchaseEvent,
+  useFetchCoverPurchasedEvent,
+} from "@/src/hooks/useFetchCoverPurchasedEvent";
+import { testData } from "@/utils/unit-tests/test-data";
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFetchCoverPurchasedEvent", () => {
+  const { mock, mockFunction } = mockFn.consoleError();
+  mock();
+
+  mockFn.useNetwork();
+  mockFn.getGraphURL();
+  jest.mock("@/lib/date/DateLib");
+
+  const args = [
+    {
+      txHash: testData.coverPurchasedEvent.transactionHash,
+    },
+  ];
+
+  test("should return default value when no data returned from api", async () => {
+    const mockData = { data: {} };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFetchCoverPurchasedEvent,
+      args
+    );
+
+    expect(result.data).toBeFalsy();
+    expect(result.loading).toBeFalsy();
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return correct data as received", async () => {
+    const mockData = {
+      data: { coverPurchasedEvent: { id: 123, timestamp: 167934354 } },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFetchCoverPurchasedEvent,
+      args,
+      true
+    );
+
+    expect(result.data).toBe(mockData.data.coverPurchasedEvent);
+    expect(result.loading).toBeFalsy();
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should log error when error returned from api", async () => {
+    mockFn.fetch(false);
+
+    await renderHookWrapper(useFetchCoverPurchasedEvent, args, true);
+    expect(mockFunction).toHaveBeenCalled();
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should get data from localstorage if available", async () => {
+    // store an event in localstorage
+    storePurchaseEvent(
+      testData.coverPurchasedEvent,
+      testData.coverPurchasedEvent.from
+    );
+
+    const { result } = await renderHookWrapper(
+      useFetchCoverPurchasedEvent,
+      args,
+      true
+    );
+
+    expect(result.data.id).toBe(testData.coverPurchasedEvent.transactionHash);
+  });
+
+  test("testing storePurchaseEvent function", () => {
+    storePurchaseEvent(
+      { ...testData.coverPurchasedEvent, transactionHash: "123456789" },
+      testData.coverPurchasedEvent.from
+    );
+
+    const storedEvent = JSON.parse(localStorage.getItem("123456789"));
+
+    expect(storedEvent).toBeDefined();
+    expect(storedEvent.event.id).toBe("123456789");
+  });
+
+  test("when localstorage data is expired", async () => {
+    // store an event in localstorage
+    storePurchaseEvent(
+      testData.coverPurchasedEvent,
+      testData.coverPurchasedEvent.from
+    );
+
+    // mock DateLib.unix method to give higher date timestamp
+    const mockStaticF = jest
+      .fn()
+      .mockReturnValue(new Date().getTime() + 999999);
+    DateLib.unix = mockStaticF;
+
+    await renderHookWrapper(useFetchCoverPurchasedEvent, args, true);
+
+    const storedEvent = localStorage.getItem(args[0].txHash);
+    expect(storedEvent).toBeFalsy();
+  });
+});

--- a/src/hooks/__tests__/useFetchCoverStats.test.jsx
+++ b/src/hooks/__tests__/useFetchCoverStats.test.jsx
@@ -1,0 +1,220 @@
+import { CoverStatus } from "@/src/config/constants";
+import {
+  defaultStats,
+  useFetchCoverStats,
+} from "@/src/hooks/useFetchCoverStats";
+import { testData } from "@/utils/unit-tests/test-data";
+
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+const checkData = (result, matchWithData = true) => {
+  if (matchWithData) {
+    expect(result.info.activeIncidentDate).toEqual(
+      testData.getcoverStats.activeIncidentDate
+    );
+    expect(result.info.claimPlatformFee).toEqual(
+      testData.getcoverStats.claimPlatformFee
+    );
+    expect(result.info.activeCommitment).toEqual(
+      testData.getcoverStats.activeCommitment
+    );
+    expect(result.info.isUserWhitelisted).toEqual(
+      testData.getcoverStats.isUserWhitelisted
+    );
+    expect(result.info.productStatus).toEqual(
+      CoverStatus[testData.getcoverStats.productStatus]
+    );
+    expect(result.info.reporterCommission).toEqual(
+      testData.getcoverStats.reporterCommission
+    );
+    expect(result.info.reportingPeriod).toEqual(
+      testData.getcoverStats.reportingPeriod
+    );
+    expect(result.info.totalPoolAmount).toEqual(
+      testData.getcoverStats.totalPoolAmount
+    );
+    expect(result.info.requiresWhitelist).toEqual(
+      testData.getcoverStats.requiresWhitelist
+    );
+    expect(result.info.availableLiquidity).toEqual(
+      testData.getcoverStats.availableLiquidity
+    );
+    expect(result.info.minReportingStake).toEqual(
+      testData.getcoverStats.minReportingStake
+    );
+  } else {
+    expect(result.info.activeIncidentDate).toEqual(
+      defaultStats.activeIncidentDate
+    );
+    expect(result.info.claimPlatformFee).toEqual(defaultStats.claimPlatformFee);
+    expect(result.info.activeCommitment).toEqual(defaultStats.activeCommitment);
+    expect(result.info.isUserWhitelisted).toEqual(
+      defaultStats.isUserWhitelisted
+    );
+    expect(result.info.reporterCommission).toEqual(
+      defaultStats.reporterCommission
+    );
+    expect(result.info.reportingPeriod).toEqual(defaultStats.reportingPeriod);
+    expect(result.info.totalPoolAmount).toEqual(defaultStats.totalPoolAmount);
+    expect(result.info.requiresWhitelist).toEqual(
+      defaultStats.requiresWhitelist
+    );
+    expect(result.info.availableLiquidity).toEqual(
+      defaultStats.availableLiquidity
+    );
+    expect(result.info.minReportingStake).toEqual(
+      defaultStats.minReportingStake
+    );
+  }
+};
+
+describe("useFetchCoverStats", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+
+  mockFn.useNetwork();
+  mockFn.useWeb3React();
+  mockFn.getStats();
+
+  const args = [
+    {
+      coverKey:
+        "0x7072696d65000000000000000000000000000000000000000000000000000000",
+      productKey:
+        "0x6161766500000000000000000000000000000000000000000000000000000000",
+    },
+  ];
+
+  test("should return data from the geStats function if account available", async () => {
+    const mockData = { data: {} };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(useFetchCoverStats, args, true);
+
+    expect(typeof result.refetch).toBe("function");
+    checkData(result);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return data from api if account not available", async () => {
+    mockFn.useWeb3React(() => ({ account: null }));
+    const mockData = { data: testData.getcoverStats };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(useFetchCoverStats, args, true);
+    checkData(result);
+
+    mockFn.fetch().unmock();
+    mockFn.useWeb3React();
+  });
+
+  test("should set data from default value if no data available from api", async () => {
+    mockFn.useWeb3React(() => ({ account: null }));
+    const mockData = { data: { activeIncidentDate: "" } };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(useFetchCoverStats, args, true);
+    checkData(result, false);
+
+    mockFn.fetch().unmock();
+    mockFn.useWeb3React();
+  });
+
+  test("should call the refetch function", async () => {
+    const { result, act } = await renderHookWrapper(
+      useFetchCoverStats,
+      args,
+      true
+    );
+
+    await act(async () => {
+      await result.refetch();
+    });
+  });
+
+  describe("Edge cases coverage", () => {
+    test("should return if no networkId found", async () => {
+      mockFn.useNetwork(() => ({ networkId: null }));
+
+      await renderHookWrapper(useFetchCoverStats, args);
+
+      mockFn.useNetwork();
+    });
+
+    test("should return if response not ok from api", async () => {
+      mockFn.useWeb3React(() => ({ account: null }));
+      mockFn.fetch(true, { ...testData.fetch, ok: false });
+
+      await renderHookWrapper(useFetchCoverStats, args);
+
+      mockFn.fetch().unmock();
+      mockFn.useWeb3React();
+    });
+
+    test("should return if null data from api", async () => {
+      mockFn.useWeb3React(() => ({ account: null }));
+      mockFn.fetch(true, undefined, { data: null });
+
+      await renderHookWrapper(useFetchCoverStats, args);
+
+      mockFn.fetch().unmock();
+      mockFn.useWeb3React();
+    });
+
+    test("should return if error returned from api", async () => {
+      mockFn.useWeb3React(() => ({ account: null }));
+      mockFn.fetch(false);
+      mock();
+
+      await renderHookWrapper(useFetchCoverStats, args);
+      expect(mockFunction).toHaveBeenCalled();
+
+      mockFn.fetch().unmock();
+      mockFn.useWeb3React();
+      restore();
+    });
+
+    test("should return if no networkId when refetch", async () => {
+      mockFn.useNetwork(() => ({ networkId: null }));
+
+      const { act, result } = await renderHookWrapper(useFetchCoverStats, args);
+
+      await act(async () => {
+        await result.refetch();
+      });
+
+      mockFn.useNetwork();
+    });
+
+    test("should return defaultvalue if no data from api when refetch", async () => {
+      mockFn.useWeb3React(() => ({ account: null }));
+      mockFn.fetch(true, undefined, { data: { id: 1 } });
+
+      const { result, act } = await renderHookWrapper(useFetchCoverStats, args);
+
+      await act(async () => {
+        await result.refetch();
+      });
+      checkData(result, false);
+
+      mockFn.useNetwork();
+    });
+
+    test("should return if error returned from api for refetch", async () => {
+      mockFn.useWeb3React(() => ({ account: null }));
+      mockFn.fetch(false);
+      mock();
+
+      const { result, act } = await renderHookWrapper(useFetchCoverStats, args);
+
+      await act(async () => {
+        await result.refetch();
+      });
+      expect(mockFunction).toHaveBeenCalled();
+
+      mockFn.fetch().unmock();
+      mockFn.useWeb3React();
+      restore();
+    });
+  });
+});

--- a/src/hooks/__tests__/useFetchHeroStats.test.jsx
+++ b/src/hooks/__tests__/useFetchHeroStats.test.jsx
@@ -1,0 +1,57 @@
+import { useFetchHeroStats } from "@/src/hooks/useFetchHeroStats";
+
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFetchHeroStats", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+
+  mockFn.getGraphURL();
+  mockFn.getNetworkId();
+
+  const mockFetchData = {
+    data: {
+      covers: [{}, {}, {}, {}],
+      cxTokens: [
+        { totalCoveredAmount: 12323 },
+        { totalCoveredAmount: 7 },
+        { totalCoveredAmount: 1000 },
+      ],
+      protocols: [
+        {
+          totalCoverLiquidityAdded: 1234,
+          totalCoverLiquidityRemoved: 5434,
+          totalFlashLoanFees: 124,
+          totalCoverFee: 1023,
+        },
+      ],
+      reporting: [{}],
+    },
+  };
+
+  test("should return correct data ", async () => {
+    mockFn.fetch(true, undefined, mockFetchData);
+
+    const { result } = await renderHookWrapper(useFetchHeroStats, [], true);
+
+    expect(result.data.availableCovers).toBeDefined();
+    expect(result.data.reportingCovers).toBeDefined();
+    expect(result.data.coverFee).toBeDefined();
+    expect(result.data.covered).toBeDefined();
+    expect(result.data.tvlCover).toBeDefined();
+    expect(result.data.tvlPool).toBeDefined();
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should log error if error returned from api", async () => {
+    mockFn.fetch(false);
+    mock();
+
+    await renderHookWrapper(useFetchHeroStats, [], true);
+
+    expect(mockFunction).toHaveBeenCalled();
+
+    mockFn.fetch().unmock();
+    restore();
+  });
+});

--- a/src/hooks/__tests__/useFetchReport.test.jsx
+++ b/src/hooks/__tests__/useFetchReport.test.jsx
@@ -1,0 +1,61 @@
+import { useFetchReport } from "@/src/hooks/useFetchReport";
+
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFetchReport", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+
+  mockFn.getGraphURL();
+  mockFn.getNetworkId();
+
+  const args = [
+    {
+      coverKey:
+        "0x7072696d65000000000000000000000000000000000000000000000000000000",
+      productKey:
+        "0x6161766500000000000000000000000000000000000000000000000000000000",
+      incidentDate: new Date().getTime(),
+    },
+  ];
+
+  test("should return correct data ", async () => {
+    const mockData = {
+      data: { incidentReport: { id: 1, reportedOn: new Date().getTime() } },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(useFetchReport, args, true);
+
+    expect(result.data).toEqual(mockData.data);
+    expect(result.loading).toBe(false);
+    expect(typeof result.refetch).toBe("function");
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should log error if api error occurs", async () => {
+    mockFn.fetch(false);
+    mock();
+
+    await renderHookWrapper(useFetchReport, args, true);
+    expect(mockFunction).toHaveBeenCalled();
+
+    mockFn.fetch().unmock();
+    restore();
+  });
+
+  test("should execute the refetch function", async () => {
+    const mockData = {
+      data: { incidentReport: { id: 1, reportedOn: new Date().getTime() } },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result, act } = await renderHookWrapper(useFetchReport, args, true);
+
+    await act(async () => {
+      await result.refetch();
+    });
+
+    mockFn.fetch().unmock();
+  });
+});

--- a/src/hooks/__tests__/useFetchReportsByKeyAndDate.test.jsx
+++ b/src/hooks/__tests__/useFetchReportsByKeyAndDate.test.jsx
@@ -1,0 +1,62 @@
+import { useFetchReportsByKeyAndDate } from "@/src/hooks/useFetchReportsByKeyAndDate";
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFetchReportsByKeyAndDate", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+
+  mockFn.getGraphURL();
+  mockFn.getNetworkId();
+
+  const args = [
+    {
+      coverKey:
+        "0x7072696d65000000000000000000000000000000000000000000000000000000",
+      incidentDate: new Date().getTime(),
+    },
+  ];
+
+  test("should return correct data ", async () => {
+    const mockData = {
+      data: { incidentReports: [{ id: 1, reportedOn: new Date().getTime() }] },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFetchReportsByKeyAndDate,
+      args,
+      true
+    );
+
+    expect(result.data).toEqual(mockData.data.incidentReports);
+    expect(result.loading).toBe(false);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return if coverkey & incident dat not provided", async () => {
+    const mockData = {
+      data: { incidentReports: [{ id: 1, reportedOn: new Date().getTime() }] },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(useFetchReportsByKeyAndDate, [
+      {},
+    ]);
+
+    expect(result.data).toEqual([]);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should log the error if error occured", async () => {
+    mockFn.fetch(false);
+    mock();
+
+    await renderHookWrapper(useFetchReportsByKeyAndDate, args, true);
+
+    expect(mockFunction).toHaveBeenCalled();
+
+    mockFn.fetch().unmock();
+    restore();
+  });
+});

--- a/src/hooks/__tests__/useFinalizeIncident.test.jsx
+++ b/src/hooks/__tests__/useFinalizeIncident.test.jsx
@@ -1,0 +1,81 @@
+import { useFinalizeIncident } from "@/src/hooks/useFinalizeIncident";
+import { testData } from "@/utils/unit-tests/test-data";
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFinalizeIncident", () => {
+  mockFn.useWeb3React();
+  mockFn.useNetwork();
+  mockFn.useAuthValidation();
+  mockFn.useTxToast();
+  mockFn.useErrorNotifier();
+  mockFn.useTxPoster();
+  mockFn.sdk.registry.Resolution.getInstance();
+
+  const args = [
+    {
+      coverKey:
+        "0x7072696d65000000000000000000000000000000000000000000000000000000",
+      productKey:
+        "0x6161766500000000000000000000000000000000000000000000000000000000",
+      incidentDate: new Date().getTime(),
+    },
+  ];
+
+  test("should return correct data ", async () => {
+    const { result } = await renderHookWrapper(useFinalizeIncident, args);
+
+    expect(typeof result.finalize).toBe("function");
+    expect(result.finalizing).toBe(false);
+  });
+
+  test("shoudl be able to execute the finalize function", async () => {
+    const { result, act } = await renderHookWrapper(useFinalizeIncident, args);
+
+    await act(async () => {
+      await result.finalize();
+    });
+  });
+
+  test("shoudl return if no networkId or account in finalize function", async () => {
+    mockFn.useNetwork(() => ({ networkId: null }));
+    mockFn.useWeb3React(() => ({ account: null }));
+
+    const { result, act } = await renderHookWrapper(useFinalizeIncident, args);
+
+    await act(async () => {
+      await result.finalize(jest.fn());
+    });
+
+    mockFn.useNetwork();
+    mockFn.useWeb3React();
+  });
+
+  describe("Edge cases coverage", () => {
+    test("shoudl use empty bytes32 if no product key provided", async () => {
+      const { result, act } = await renderHookWrapper(useFinalizeIncident, [
+        { ...args[0], productKey: "" },
+      ]);
+
+      await act(async () => {
+        await result.finalize(jest.fn());
+      });
+    });
+
+    test("shoudl return if error in writing to contract", async () => {
+      mockFn.useTxPoster(() => ({
+        ...testData.txPoster,
+        writeContract: null,
+      }));
+
+      const { result, act } = await renderHookWrapper(
+        useFinalizeIncident,
+        args
+      );
+
+      await act(async () => {
+        await result.finalize(jest.fn());
+      });
+      expect(testData.errorNotifier.notifyError).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/__tests__/useFlattenedCoverProducts.test.jsx
+++ b/src/hooks/__tests__/useFlattenedCoverProducts.test.jsx
@@ -1,0 +1,62 @@
+import { useFlattenedCoverProducts } from "@/src/hooks/useFlattenedCoverProducts";
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useFlattenedCoverProducts", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+  mockFn.useNetwork();
+  mockFn.getGraphURL();
+  mockFn.getNetworkId();
+
+  test("should return correct data ", async () => {
+    mockFn.fetch();
+
+    const { result } = await renderHookWrapper(useFlattenedCoverProducts, []);
+
+    expect(result.data).toEqual([]);
+    expect(result.loading).toBe(false);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return correct data as returned from api", async () => {
+    const mockData = { data: { coverProducts: [{ id: 1 }, { id: 2 }] } };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFlattenedCoverProducts,
+      [],
+      true
+    );
+
+    expect(result.data).toEqual(mockData.data.coverProducts);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return empty array if no data returned from api", async () => {
+    const mockData = { data: null };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(
+      useFlattenedCoverProducts,
+      [],
+      true
+    );
+
+    expect(result.data).toEqual([]);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should log error if api error", async () => {
+    mockFn.fetch(false);
+    mock();
+
+    await renderHookWrapper(useFlattenedCoverProducts, [], true);
+
+    expect(mockFunction).toHaveBeenCalled();
+
+    restore();
+    mockFn.fetch().unmock();
+  });
+});

--- a/src/hooks/__tests__/useIfWhitelisted.test.jsx
+++ b/src/hooks/__tests__/useIfWhitelisted.test.jsx
@@ -1,0 +1,62 @@
+import { useIfWhitelisted } from "@/src/hooks/useIfWhitelisted";
+import { testData } from "@/utils/unit-tests/test-data";
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useIfWhitelisted", () => {
+  mockFn.useWeb3React();
+  mockFn.useNetwork();
+  mockFn.useTxPoster();
+  mockFn.useErrorNotifier();
+  mockFn.sdk.registry.Cover.getInstance();
+
+  const args = [
+    {
+      coverKey:
+        "0x7072696d65000000000000000000000000000000000000000000000000000000",
+    },
+  ];
+
+  test("should return isUserWhitelisted true if transaction success", async () => {
+    const { result } = await renderHookWrapper(useIfWhitelisted, args, true);
+
+    expect(result.isUserWhitelisted).toBe(true);
+  });
+
+  test("should return if no networkId or account", async () => {
+    mockFn.useWeb3React(() => ({ account: null }));
+    mockFn.useNetwork(() => ({ networkId: null }));
+
+    const { result } = await renderHookWrapper(useIfWhitelisted, args);
+
+    expect(result.isUserWhitelisted).toBe(false);
+
+    mockFn.useWeb3React();
+    mockFn.useNetwork();
+  });
+
+  test("should return isUserWhitelisted false if no tx result received", async () => {
+    mockFn.useTxPoster(() => ({
+      ...testData.txPoster,
+      writeContract: jest.fn((arg) => {
+        arg?.onTransactionResult?.(null);
+        arg?.onRetryCancel?.();
+        arg?.onError?.();
+      }),
+    }));
+
+    const { result } = await renderHookWrapper(useIfWhitelisted, args);
+
+    expect(result.isUserWhitelisted).toBe(false);
+  });
+
+  test("should execute notifyError function if error occured", async () => {
+    mockFn.useTxPoster(() => ({
+      ...testData.txPoster,
+      writeContract: null,
+    }));
+
+    await renderHookWrapper(useIfWhitelisted, args);
+
+    expect(testData.errorNotifier.notifyError).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/__tests__/useLiquidityTxs.test.jsx
+++ b/src/hooks/__tests__/useLiquidityTxs.test.jsx
@@ -1,0 +1,96 @@
+import { useLiquidityTxs } from "@/src/hooks/useLiquidityTxs";
+import { mockFn, renderHookWrapper } from "@/utils/unit-tests/test-mockup-fn";
+
+describe("useLiquidityTxs", () => {
+  const { mock, mockFunction, restore } = mockFn.consoleError();
+  mockFn.useWeb3React();
+  mockFn.useNetwork();
+  mockFn.getGraphURL();
+
+  const args = [
+    {
+      limit: 10,
+      page: 1,
+    },
+  ];
+
+  test("should return default data", async () => {
+    mockFn.fetch();
+
+    const { result } = await renderHookWrapper(useLiquidityTxs, args, true);
+
+    expect(result.hasMore).toBe(true);
+    expect(result.data.blockNumber).toEqual(null);
+    expect(result.data.transactions).toEqual([]);
+    expect(result.data.totalCount).toEqual(0);
+    expect(result.loading).toEqual(false);
+
+    mockFn.fetch().unmock();
+  });
+
+  test("should return correct data as received from api", async () => {
+    const mockData = {
+      data: {
+        liquidityTransactions: [{ id: 1 }, { id: 2 }],
+        _meta: { block: { number: 1234 } },
+      },
+    };
+    mockFn.fetch(true, undefined, mockData);
+
+    const { result } = await renderHookWrapper(useLiquidityTxs, args, true);
+
+    const hasMore =
+      mockData.data.liquidityTransactions.length === 0 ||
+      mockData.data.liquidityTransactions.length < args[0].limit;
+    expect(result.hasMore).toBe(!hasMore);
+    expect(result.data.blockNumber).toEqual(mockData.data._meta.block.number);
+    expect(result.data.transactions).toEqual(
+      mockData.data.liquidityTransactions
+    );
+    expect(result.data.totalCount).toEqual(
+      mockData.data.liquidityTransactions.length
+    );
+
+    mockFn.fetch().unmock();
+  });
+
+  describe("Edge cases coverage", () => {
+    test("should return if no account", async () => {
+      mockFn.useWeb3React(() => ({ account: null }));
+
+      const { result } = await renderHookWrapper(useLiquidityTxs, args);
+      expect(result.data.transactions).toEqual([]);
+
+      mockFn.useWeb3React();
+    });
+
+    test("should not set hasMore to false if transactions length is equal to limit", async () => {
+      const mockData = {
+        data: {
+          liquidityTransactions: [{ id: 1 }, { id: 2 }],
+          _meta: { block: { number: 1234 } },
+        },
+      };
+      mockFn.fetch(true, undefined, mockData);
+
+      const { result } = await renderHookWrapper(useLiquidityTxs, [
+        { page: 1, limit: 2 },
+      ]);
+
+      expect(result.hasMore).toEqual(true);
+      mockFn.fetch().unmock();
+    });
+
+    test("should log error in case of api error", async () => {
+      mockFn.fetch(false);
+      mock();
+
+      await renderHookWrapper(useLiquidityTxs, args);
+
+      expect(mockFunction).toHaveBeenCalled();
+
+      mockFn.fetch().unmock();
+      restore();
+    });
+  });
+});

--- a/src/hooks/useFetchCoverStats.jsx
+++ b/src/hooks/useFetchCoverStats.jsx
@@ -2,11 +2,15 @@ import { useCallback, useEffect, useState } from "react";
 import { useWeb3React } from "@web3-react/core";
 import { useNetwork } from "@/src/context/Network";
 import { getReplacedString } from "@/utils/string";
-import { ADDRESS_ONE, CoverStatus, COVER_STATS_URL } from "@/src/config/constants";
+import {
+  ADDRESS_ONE,
+  CoverStatus,
+  COVER_STATS_URL,
+} from "@/src/config/constants";
 import { getStats } from "@/src/services/protocol/cover/stats";
 import { getProviderOrSigner } from "@/lib/connect-wallet/utils/web3";
 
-const defaultStats = {
+export const defaultStats = {
   activeIncidentDate: "0",
   claimPlatformFee: "0",
   activeCommitment: "0",
@@ -33,7 +37,13 @@ export const useFetchCoverStats = ({ coverKey, productKey }) => {
     if (account) {
       // Get data from provider if wallet's connected
       const signerOrProvider = getProviderOrSigner(library, account, networkId);
-      data = await getStats(networkId, coverKey, productKey, account, signerOrProvider.provider);
+      data = await getStats(
+        networkId,
+        coverKey,
+        productKey,
+        account,
+        signerOrProvider.provider
+      );
     } else {
       // Get data from API if wallet's not connected
       const response = await fetch(
@@ -76,17 +86,27 @@ export const useFetchCoverStats = ({ coverKey, productKey }) => {
         if (ignore || !data) return;
 
         setInfo({
-          activeIncidentDate: data.activeIncidentDate || defaultStats.activeIncidentDate,
-          claimPlatformFee: data.claimPlatformFee || defaultStats.claimPlatformFee,
-          activeCommitment: data.activeCommitment || defaultStats.activeCommitment,
-          isUserWhitelisted: data.isUserWhitelisted || defaultStats.isUserWhitelisted,
-          reporterCommission: data.reporterCommission || defaultStats.reporterCommission,
+          activeIncidentDate:
+            data.activeIncidentDate || defaultStats.activeIncidentDate,
+          claimPlatformFee:
+            data.claimPlatformFee || defaultStats.claimPlatformFee,
+          activeCommitment:
+            data.activeCommitment || defaultStats.activeCommitment,
+          isUserWhitelisted:
+            data.isUserWhitelisted || defaultStats.isUserWhitelisted,
+          reporterCommission:
+            data.reporterCommission || defaultStats.reporterCommission,
           reportingPeriod: data.reportingPeriod || defaultStats.reportingPeriod,
-          requiresWhitelist: data.requiresWhitelist || defaultStats.requiresWhitelist,
-          productStatus: CoverStatus[data.productStatus] || CoverStatus[defaultStats.productStatus],
+          requiresWhitelist:
+            data.requiresWhitelist || defaultStats.requiresWhitelist,
+          productStatus:
+            CoverStatus[data.productStatus] ||
+            CoverStatus[defaultStats.productStatus],
           totalPoolAmount: data.totalPoolAmount || defaultStats.totalPoolAmount,
-          availableLiquidity: data.availableLiquidity || defaultStats.availableLiquidity,
-          minReportingStake: data.minReportingStake || defaultStats.minReportingStake,
+          availableLiquidity:
+            data.availableLiquidity || defaultStats.availableLiquidity,
+          minReportingStake:
+            data.minReportingStake || defaultStats.minReportingStake,
         });
       } catch (error) {
         console.error(error);
@@ -107,17 +127,27 @@ export const useFetchCoverStats = ({ coverKey, productKey }) => {
       if (!data) return;
 
       setInfo({
-        activeIncidentDate: data.activeIncidentDate || defaultStats.activeIncidentDate,
-        claimPlatformFee: data.claimPlatformFee || defaultStats.claimPlatformFee,
-        activeCommitment: data.activeCommitment || defaultStats.activeCommitment,
-        isUserWhitelisted: data.isUserWhitelisted || defaultStats.isUserWhitelisted,
-        reporterCommission: data.reporterCommission || defaultStats.reporterCommission,
+        activeIncidentDate:
+          data.activeIncidentDate || defaultStats.activeIncidentDate,
+        claimPlatformFee:
+          data.claimPlatformFee || defaultStats.claimPlatformFee,
+        activeCommitment:
+          data.activeCommitment || defaultStats.activeCommitment,
+        isUserWhitelisted:
+          data.isUserWhitelisted || defaultStats.isUserWhitelisted,
+        reporterCommission:
+          data.reporterCommission || defaultStats.reporterCommission,
         reportingPeriod: data.reportingPeriod || defaultStats.reportingPeriod,
-        requiresWhitelist: data.requiresWhitelist || defaultStats.requiresWhitelist,
-        productStatus: CoverStatus[data.productStatus] || CoverStatus[defaultStats.productStatus],
+        requiresWhitelist:
+          data.requiresWhitelist || defaultStats.requiresWhitelist,
+        productStatus:
+          CoverStatus[data.productStatus] ||
+          CoverStatus[defaultStats.productStatus],
         totalPoolAmount: data.totalPoolAmount || defaultStats.totalPoolAmount,
-        availableLiquidity: data.availableLiquidity || defaultStats.availableLiquidity,
-        minReportingStake: data.minReportingStake || defaultStats.minReportingStake,
+        availableLiquidity:
+          data.availableLiquidity || defaultStats.availableLiquidity,
+        minReportingStake:
+          data.minReportingStake || defaultStats.minReportingStake,
       });
     } catch (error) {
       console.error(error);

--- a/src/utils/unit-tests/test-data.js
+++ b/src/utils/unit-tests/test-data.js
@@ -1302,6 +1302,39 @@ export const testData = {
   authValidation: {
     requiresAuth: jest.fn(),
   },
+  coverPurchasedEvent: {
+    transactionHash:
+      "0x6b1bbdd7844aa52d1f2267770a8a3ee910d85524ec60477f45f3a550eafddf8d",
+    args: {
+      coverKey:
+        "0x616e696d617465642d6272616e64730000000000000000000000000000000000",
+      productKey:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      onBehalfOf: "0x2d2caD7Eed8EDD9B11E30C01C45483fA40E819d9",
+      cxToken: "0x0FDc3e2aFd39a4370f5d493D5D2576B8aB3c5258",
+      fee: toBN("100"),
+      platformFee: toBN("100"),
+      amountToCover: toBN("100"),
+      expiresOn: toBN("100"),
+      referralCode:
+        "0x0000000000000000000000000000000000000000000000000000000000000000",
+      policyId: toBN("100"),
+    },
+    from: "0x2d2caD7Eed8EDD9B11E30C01C45483fA40E819d9",
+  },
+  getcoverStats: {
+    totalPoolAmount: "4306087000000",
+    activeCommitment: "0",
+    availableLiquidity: "4306087000000",
+    reporterCommission: "1000",
+    claimPlatformFee: "650",
+    reportingPeriod: "1800",
+    productStatus: "",
+    minReportingStake: "5000000000000000000000",
+    activeIncidentDate: "0",
+    requiresWhitelist: true,
+    isUserWhitelisted: false,
+  },
   myLiquidities: {
     data: { liquidityList: [], myLiquidities: {} },
     loading: false,

--- a/src/utils/unit-tests/test-mockup-fn.js
+++ b/src/utils/unit-tests/test-mockup-fn.js
@@ -67,6 +67,7 @@ import * as FetchReport from "@/src/hooks/useFetchReport";
 
 import * as ConsensusReportingInfoHook from "@/src/hooks/useConsensusReportingInfo";
 import * as RecentVotesHook from "@/src/hooks/useRecentVotes";
+import * as GetStatsFile from "@/src/services/protocol/cover/stats";
 import * as UnstakeReportingStakeHook from "@/src/hooks/useUnstakeReportingStake";
 import * as RetryUntilPassedHook from "@/src/hooks/useRetryUntilPassed";
 import * as UseVoteHook from "@/src/hooks/useVote";
@@ -471,6 +472,24 @@ export const mockFn = {
           );
         },
       },
+      Resolution: {
+        getInstance: (returnUndefined = false) => {
+          NeptuneMutualSDK.registry.Resolution.getInstance = jest.fn(() =>
+            Promise.resolve(
+              returnUndefined ? undefined : "Resolution geInstance() mock"
+            )
+          );
+        },
+      },
+      Cover: {
+        getInstance: (returnUndefined = false) => {
+          NeptuneMutualSDK.registry.Cover.getInstance = jest.fn(() =>
+            Promise.resolve(
+              returnUndefined ? undefined : "Cover geInstance() mock"
+            )
+          );
+        },
+      },
     },
     utils: {
       ipfs: {
@@ -510,6 +529,8 @@ export const mockFn = {
     jest
       .spyOn(AuthValidationHook, "useAuthValidation")
       .mockImplementation(returnFunction(cb)),
+  getStats: (cb = () => Promise.resolve(testData.getcoverStats)) =>
+    jest.spyOn(GetStatsFile, "getStats").mockImplementation(returnFunction(cb)),
   useMyLiquidities: (cb = () => testData.myLiquidities) => {
     jest
       .spyOn(MyLiqudities, "useMyLiquidities")


### PR DESCRIPTION
Added tests for following hooks:
  - `useFetchCoverPurchasedEvent`
  - `useFetchCoverProductActiveReportings`
  - `useFetchCoverStats`
  - `useFetchHeroStats`
  - `useFetchReport`
  - `useFetchReportsByKeyAndDate`
  - `useFinalizeIncident`
  - `useFlattenedCoverProducts`
  - `useIfWhitelisted`
  - `useLiquidityTxs`