### PR TITLE
Fix:IPFS upload issue

### DIFF
--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -56,7 +56,7 @@ export const GET_CONTRACTS_INFO_URL = `${API_BASE_URL}protocol/contracts/{networ
 export const VAULT_INFO_URL = `${API_BASE_URL}protocol/vault/info/{networkId}/{coverKey}/{account}`
 export const REFERRAL_CODE_VALIDATION_URL = `${API_BASE_URL}protocol/cover/referral-code`
 
-export const IPFS_REPORT_INFO_URL = `${API_BASE_URL}ipfs/reporting-info`
+export const IPFS_REPORT_INFO_URL = `${API_BASE_URL}ipfs/report-info`
 export const IPFS_DISPUTE_INFO_URL = `${API_BASE_URL}ipfs/dispute-info`
 
 export const POOL_URLS = {

--- a/src/modules/reporting/NewDisputeReportForm.jsx
+++ b/src/modules/reporting/NewDisputeReportForm.jsx
@@ -89,7 +89,7 @@ export const NewDisputeReportForm = ({ incidentReport, minReportingStake }) => {
 
     const payload = {
       title: current.title?.value,
-      proofOfDispute: urlReports,
+      proofOfDispute: urlReports.join(','),
       description: current.description?.value,
       stake: convertToUnits(value).toString()
     }

--- a/src/modules/reporting/NewIncidentReportForm.jsx
+++ b/src/modules/reporting/NewIncidentReportForm.jsx
@@ -124,8 +124,8 @@ export function NewIncidentReportForm ({ coverKey, productKey, minReportingStake
 
       const payload = {
         title: current?.title?.value,
-        observed: new Date(current?.incident_date?.value),
-        proofOfIncident: urlReports,
+        observed: DateLib.toUnix(new Date(current?.incident_date?.value)),
+        proofOfIncident: urlReports.join(','),
         description: current?.description?.value,
         stake: convertToUnits(value).toString()
       }

--- a/src/utils/ipfs.js
+++ b/src/utils/ipfs.js
@@ -7,7 +7,7 @@ const urls = {
 }
 
 const getPermalink = (type, networkId, data) => {
-  const hostname = config.networks.getChainConfig(networkId)
+  const { hostname } = config.networks.getChainConfig(networkId)
 
   if (type === 'report') {
     return `https://${hostname}/reports/${data.coverKey}/products/${data.productKey}`
@@ -35,6 +35,7 @@ const writeToIpfs = async ({ payload, account, networkId, type, data }) => {
       method: 'PUT',
       body: JSON.stringify(_payload),
       headers: {
+        'Content-Type': 'application/json',
         siteId: process.env.NEXT_PUBLIC_SITE_ID
       }
     })


### PR DESCRIPTION
Fixed ipfs uploading issues:
  - updated ipfs reporting endpoint from `/ipfs/reporting-info` to `/ipfs/report-info`
  - updating hostname code due to change in sdk `config`
  - changed `observed` payload type from date string to unix timestamp in reporting payload
  - changed `proofOfIncident` from array of string to a concatenated string in reporting payload
  - changed `proofOfIncident` from array of string to a concatenated string in dispute payload