### PR TITLE
Fixed unable to continue with empty referral code in purchase policy …

### DIFF
--- a/src/hooks/useValidateReferralCode.jsx
+++ b/src/hooks/useValidateReferralCode.jsx
@@ -47,6 +47,7 @@ export function useValidateReferralCode (referralCode, setIsReferralCodeCheckPen
         // if it's empty we set true immediately
         setErrorMessage('')
         setIsValid(true)
+        setIsReferralCodeCheckPending(false)
 
         return
       }
@@ -55,6 +56,7 @@ export function useValidateReferralCode (referralCode, setIsReferralCodeCheckPen
       if (!isValidReferralCode(trimmedValue)) {
         setErrorMessage(t`Incorrect Cashback Code`)
         setIsValid(false)
+        setIsReferralCodeCheckPending(false)
 
         return
       }


### PR DESCRIPTION
## Changes
- Used `setIsReferralCodeCheckPending(false)` in case of early return inside of `useValidateReferralCode` hook